### PR TITLE
Native text selection + system clipboard (v1.7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Pretty much everything:
 - History with Ctrl+R and autosuggestions
 - Tab completion for commands, paths, and variables
 - Syntax highlighting as you type
+- Native text selection with Shift+Arrow + system clipboard (pbcopy / xclip / wl-copy / xsel)
 - Arrays (indexed and associative)
 - Full parameter expansion (`${var#pattern}`, `${var//find/replace}`, `${var^^}`, etc.)
 - Process substitution (`<(cmd)`, `>(cmd)`)
@@ -58,6 +59,7 @@ Pretty much everything:
 - Vi and Emacs editing modes
 - Per-builtin help texts (`help cd`, `help export`, etc.)
 - fzf integration (file browser, history search, directory jump, git browser)
+- Bracketed paste mode (large pastes land atomically)
 
 ## What Doesn't Work
 
@@ -152,6 +154,29 @@ Works with Tab completion. Valid directories highlight green.
 | Alt-J | Search directories |
 | Ctrl-H | Search history |
 | Alt-G | Search git files |
+
+**Text selection** (live since v1.7.0 — works like a GUI editor in the terminal):
+
+| Key | Action |
+|-----|--------|
+| Shift+Left / Shift+Right | Extend selection by character |
+| Shift+Home / Shift+End | Extend selection to line start / end |
+| Shift+Up / Shift+Down | Extend selection line-wise (Home / End on single-line prompt) |
+| Ctrl+Shift+Left / Ctrl+Shift+Right | Extend selection by word |
+| Alt+Shift+B / Alt+Shift+F | Extend selection by word (emacs-native alias) |
+| any plain motion (Left, Home, Alt+b, ...) | Collapse selection — char-motions snap to the appropriate edge |
+| Ctrl+W or Ctrl+X | Cut selection (writes to kill buffer + system clipboard) |
+| Alt+W | Copy selection (kill buffer + system clipboard, no delete) |
+| Ctrl+Y | Paste from kill buffer (deletes selection first if active) |
+| Ctrl+V | Paste from system clipboard (falls back to kill buffer if no tool) |
+| typing a printable char | Replaces the selection in place (type-over) |
+| Backspace / Delete | Removes the entire selection |
+
+System clipboard bridge auto-detects `pbcopy` (macOS), `wl-copy` (Wayland), `xclip` or `xsel` (X11) at startup. If none are installed, cut/copy still work via the in-session kill buffer.
+
+Env flags:
+- `FORTSH_DEBUG_SELECTION=1` — dump selection state to stderr on each mutation
+- `FORTSH_NO_BRACKETED_PASTE=1` — disable `ESC[?2004h` emit (terminal-compat triage)
 
 ### Tab Completion
 

--- a/src/common/version.f90
+++ b/src/common/version.f90
@@ -7,7 +7,7 @@ module version
   private
   public :: FORTSH_VERSION, print_version, print_help
 
-  character(len=*), parameter :: FORTSH_VERSION = "1.5.0"
+  character(len=*), parameter :: FORTSH_VERSION = "1.7.0"
 
 contains
 
@@ -39,6 +39,7 @@ contains
     write(output_unit, '(a)') '  - Tab completion for commands, files, and variables'
     write(output_unit, '(a)') '  - History search with Ctrl-R'
     write(output_unit, '(a)') '  - Vi and Emacs editing modes'
+    write(output_unit, '(a)') '  - Native text selection (Shift+Arrow) with system clipboard'
     write(output_unit, '(a)') '  - Job control (fg, bg, jobs)'
     write(output_unit, '(a)') '  - Shell functions and aliases'
     write(output_unit, '(a)') '  - Pipes, process substitution, and coprocesses'

--- a/src/io/readline.f90
+++ b/src/io/readline.f90
@@ -699,6 +699,32 @@ contains
     call debug_selection_log('extend', state)
   end subroutine update_selection_on_shift_motion
 
+  ! Copy the selected byte range into the kill buffer. No-op if selection
+  ! is not active. Does NOT modify the main buffer or clear the selection —
+  ! callers decide whether this is a copy (Alt+W) or a cut (Ctrl+W) by
+  ! whether they follow up with delete_selection + collapse.
+  subroutine copy_selection_to_kill_buffer(state)
+    type(input_state_t), intent(inout) :: state
+    integer :: sel_start, sel_end, span
+    character(len=MAX_LINE_LEN) :: temp_buf
+
+    if (.not. state%selection_active) return
+    if (state%selection_anchor < 0) return
+
+    sel_start = min(state%selection_anchor, state%cursor_pos)
+    sel_end   = max(state%selection_anchor, state%cursor_pos)
+    span      = sel_end - sel_start
+
+    if (span <= 0) return
+
+    ! state_buffer_get returns 1-indexed character data; sel_start/sel_end
+    ! are 0-based byte offsets, so the slice is [sel_start+1 .. sel_end].
+    call state_buffer_get(state, temp_buf)
+    call state_kill_buffer_set(state, temp_buf(sel_start+1:sel_end))
+    state%kill_length = span
+    call debug_selection_log('copy-to-kill', state)
+  end subroutine copy_selection_to_kill_buffer
+
   ! Remove the selected byte range from the buffer, set cursor to the left
   ! edge, and clear selection state. No-op if selection is not active.
   ! Unused in Sprint 1 itself, but lands now for use in Sprint 3.
@@ -4212,6 +4238,10 @@ contains
     logical :: debug_utf8
     integer :: debug_stat
 
+    ! Shift-phase type-over (Sprint 3): replace active selection before
+    ! inserting a new multi-byte character.
+    if (input_state%selection_active) call delete_selection(input_state)
+
     ! Check if UTF-8 debug mode is enabled
     call get_environment_variable('FORTSH_DEBUG_UTF8', status=debug_stat)
     debug_utf8 = (debug_stat == 0)
@@ -4294,6 +4324,11 @@ contains
     character, intent(in) :: ch
     integer :: term_cols
     character(len=:), allocatable :: temp_buffer  ! Heap allocation to avoid stack overflow
+
+    ! Shift-phase type-over (Sprint 3): typing a character while a selection
+    ! is active replaces the selection. delete_selection removes the bytes,
+    ! moves cursor to the left edge, and clears selection state.
+    if (input_state%selection_active) call delete_selection(input_state)
 
     ! Allocate temp buffer on heap
     allocate(character(len=MAX_LINE_LEN) :: temp_buffer)
@@ -4496,6 +4531,14 @@ contains
     integer :: i
     integer :: bytes_to_delete, delete_count
 
+    ! Shift-phase (Sprint 3): Backspace on an active selection deletes the
+    ! whole range — no further character deletion. The key is "consumed".
+    if (input_state%selection_active) then
+      call delete_selection(input_state)
+      call update_autosuggestion(input_state)
+      return
+    end if
+
     ! Defensive checks for buffer corruption
     if (input_state%cursor_pos <= 0) return
     if (input_state%length <= 0) return
@@ -4564,6 +4607,14 @@ contains
   subroutine handle_forward_delete_char(input_state)
     type(input_state_t), intent(inout) :: input_state
     integer :: i, bytes_to_delete, delete_count
+
+    ! Shift-phase (Sprint 3): Delete on an active selection removes the
+    ! whole range and consumes the key.
+    if (input_state%selection_active) then
+      call delete_selection(input_state)
+      call update_autosuggestion(input_state)
+      return
+    end if
 
     ! Nothing to delete if cursor is at end or buffer is empty
     if (input_state%cursor_pos >= input_state%length) return
@@ -5942,8 +5993,18 @@ contains
         ! Alt+c - Capitalize word (uppercase first char, lowercase rest)
         call handle_capitalize_word(input_state)
       case('w')
-        ! Alt+w - Accept one word from autosuggestion
-        if (input_state%cursor_pos == input_state%length .and. &
+        ! Alt+w — dual-mode:
+        !   1. If a selection is active, copy it to the kill buffer and
+        !      collapse selection (emacs kill-ring-save). Buffer unchanged;
+        !      Ctrl+Y yanks it back wherever the user moves next.
+        !   2. Else if the cursor is at end-of-buffer with a live autosuggestion,
+        !      accept one word from the suggestion (existing behavior).
+        ! (Sprint 5 adds the system-clipboard mirror.)
+        if (input_state%selection_active) then
+          call copy_selection_to_kill_buffer(input_state)
+          call collapse_selection(input_state)
+          input_state%dirty = .true.  ! force redraw without reverse video
+        else if (input_state%cursor_pos == input_state%length .and. &
             input_state%suggestion_length > 0) then
           call accept_autosuggestion_word(input_state)
         end if
@@ -7177,6 +7238,16 @@ contains
     integer :: word_start, i
     character(len=MAX_LINE_LEN) :: temp_buf
 
+    ! Shift-phase (Sprint 3): Ctrl+W with an active selection becomes a
+    ! cut — copy the selected range to the kill buffer, then remove it.
+    ! No fall-through to kill-word. Ctrl+Y (handle_yank) pastes it back.
+    if (input_state%selection_active) then
+      call copy_selection_to_kill_buffer(input_state)
+      call delete_selection(input_state)
+      call update_autosuggestion(input_state)
+      return
+    end if
+
     if (input_state%cursor_pos == 0) then
       input_state%kill_length = 0
       return
@@ -7261,7 +7332,13 @@ contains
   subroutine handle_yank(input_state)
     type(input_state_t), intent(inout) :: input_state
     integer :: i, insert_len
-    
+
+    ! Shift-phase (Sprint 3): yanking into an active selection first
+    ! deletes the selection, then pastes the kill buffer at the cursor.
+    ! This gives the natural "paste over" behavior. Selection is collapsed
+    ! by delete_selection before the existing yank logic runs.
+    if (input_state%selection_active) call delete_selection(input_state)
+
     if (input_state%kill_length == 0) return
     
     insert_len = min(input_state%kill_length, MAX_LINE_LEN - input_state%length)

--- a/src/io/readline.f90
+++ b/src/io/readline.f90
@@ -1147,6 +1147,7 @@ contains
     integer :: suggestion_display_len, available_space
     integer :: current_col, current_row
     integer :: highlighted_len  ! Actual length of highlighted string
+    integer :: sel_start, sel_end  ! Selection byte range for Sprint 2 rendering
     character(len=MAX_LINE_LEN) :: temp_buf  ! For buffer extraction
     ! Variables for UTF-8 support (moved out of block to avoid flang-new crash)
     character(len=4) :: utf8_char
@@ -1657,8 +1658,37 @@ contains
               ! Try syntax highlighting
               call state_buffer_get(module_input_state, temp_buf)
 
+              ! Shift-phase selection rendering (Sprint 2): when a selection is
+              ! active, render in three segments — plain prefix, reverse-video
+              ! selection (ESC[7m...ESC[27m), plain suffix. Syntax highlighting
+              ! is skipped for the whole line while a selection is live to avoid
+              ! mis-coloring partial token substrings. Reverse video (#13) is
+              ! preferred over background colors: proven on Terminal.app,
+              ! iTerm2, Ghostty, and the mainstream Linux terminals, and already
+              ! used for prefix search rendering below.
+              if (module_input_state%selection_active) then
+                ! Compute and clamp the byte range.
+                sel_start = min(module_input_state%selection_anchor, module_input_state%cursor_pos)
+                sel_end   = max(module_input_state%selection_anchor, module_input_state%cursor_pos)
+                if (sel_start < 0) sel_start = 0
+                if (sel_end > module_input_state%length) sel_end = module_input_state%length
+                ! Segment 1: plain text from start up to selection start.
+                if (sel_start > 0) then
+                  write(output_unit, '(a)', advance='no') temp_buf(1:sel_start)
+                end if
+                ! Segment 2: selected bytes in reverse video.
+                if (sel_end > sel_start) then
+                  write(output_unit, '(a)', advance='no') char(27) // '[7m'
+                  write(output_unit, '(a)', advance='no') temp_buf(sel_start+1:sel_end)
+                  write(output_unit, '(a)', advance='no') char(27) // '[27m'
+                end if
+                ! Segment 3: plain text from selection end to buffer end.
+                if (sel_end < module_input_state%length) then
+                  write(output_unit, '(a)', advance='no') temp_buf(sel_end+1:module_input_state%length)
+                end if
+
               ! In prefix search mode, render prefix in reverse video + rest plain
-              if (module_input_state%in_prefix_search .and. &
+              else if (module_input_state%in_prefix_search .and. &
                   (module_input_state%prefix_search_idx /= 0 .or. module_input_state%prefix_search_flash)) then
                 ! Prefix in reverse video
                 write(output_unit, '(a)', advance='no') char(27) // '[7m'

--- a/src/io/readline.f90
+++ b/src/io/readline.f90
@@ -209,6 +209,13 @@ module readline
     type(string_ref) :: menu_prefix_ref
     type(string_ref) :: selected_process_name_ref
 #endif
+
+    ! Text selection state (shift phase, Sprint 1)
+    ! Appended at end of type per overview.md pattern #5 — do not reorder.
+    ! Selection range is [min(anchor, cursor_pos) .. max(anchor, cursor_pos))
+    ! measured in BYTES (consistent with cursor_pos and length — pattern #11).
+    integer :: selection_anchor = -1      ! -1 = no anchor set
+    logical :: selection_active = .false. ! .true. iff a selection is live
   end type input_state_t
 
   type :: history_t
@@ -257,6 +264,19 @@ module readline
 
   ! Track whether the search status line is currently displayed below the prompt
   logical, save :: module_search_status_shown = .false.
+
+  ! Shift-phase selection state (Sprint 1)
+  ! When .true., the next base movement handler call should extend the active
+  ! selection rather than collapse it. Set by the shift-arrow dispatch in
+  ! handle_extended_escape_sequence immediately before calling a base handler,
+  ! cleared immediately after. Module-level rather than per-state so handlers
+  ! don't need a new parameter (avoids flang-new derived-type ABI issues — #6).
+  logical, save :: module_extending_selection = .false.
+
+  ! FORTSH_DEBUG_SELECTION env flag — dumps selection state to stderr when set.
+  ! Probed once at init; cached. Pattern #20 from overview.md.
+  logical, save :: debug_selection = .false.
+  logical, save :: debug_selection_initialized = .false.
 
 contains
 
@@ -590,6 +610,138 @@ contains
 
   !============================================================================
   ! END BUFFER OPERATION WRAPPERS
+  !============================================================================
+
+  !============================================================================
+  ! TEXT SELECTION HELPERS (shift phase, Sprint 1)
+  !============================================================================
+  ! Three-state machine:
+  !   - Inactive:  selection_anchor = -1, selection_active = .false.
+  !   - Active:    selection_anchor in [0, length], selection_active = .true.,
+  !                selected range = [min(anchor, cursor_pos), max(anchor, cursor_pos))
+  !
+  ! Extending vs collapsing:
+  !   - Shift+motion calls set module_extending_selection=.true. before calling
+  !     a base movement handler, then call update_selection_on_shift_motion()
+  !     after to install/extend the selection against the old cursor position.
+  !   - Plain motion handlers check module_extending_selection at the top; if
+  !     .false. and selection_active, they collapse (char motions snap to the
+  !     appropriate edge; word/line motions just clear state and proceed).
+  !============================================================================
+
+  ! Initialize debug flag from environment (idempotent).
+  subroutine init_debug_selection()
+    integer :: status
+    character(len=8) :: env_val
+    if (debug_selection_initialized) return
+    call get_environment_variable('FORTSH_DEBUG_SELECTION', env_val, status=status)
+    debug_selection = (status == 0 .and. trim(env_val) == '1')
+    debug_selection_initialized = .true.
+  end subroutine init_debug_selection
+
+  ! Emit a debug trace line if FORTSH_DEBUG_SELECTION=1.
+  subroutine debug_selection_log(tag, state)
+    use iso_fortran_env, only: error_unit
+    character(len=*), intent(in) :: tag
+    type(input_state_t), intent(in) :: state
+    if (.not. debug_selection_initialized) call init_debug_selection()
+    if (.not. debug_selection) return
+    if (state%selection_active) then
+      write(error_unit, '(a,a,a,i0,a,i0,a,i0,a,l1)') &
+        '[SEL:', trim(tag), '] cursor_pos=', state%cursor_pos, &
+        ' anchor=', state%selection_anchor, &
+        ' length=', state%length, &
+        ' active=', state%selection_active
+    else
+      write(error_unit, '(a,a,a,i0,a,i0,a,l1)') &
+        '[SEL:', trim(tag), '] cursor_pos=', state%cursor_pos, &
+        ' length=', state%length, &
+        ' active=', state%selection_active
+    end if
+  end subroutine debug_selection_log
+
+  ! Clear selection state (no cursor motion, no dirty flag).
+  ! Caller is responsible for setting dirty if a redraw is needed.
+  subroutine collapse_selection(state)
+    type(input_state_t), intent(inout) :: state
+    if (.not. state%selection_active) return
+    state%selection_anchor = -1
+    state%selection_active = .false.
+    call debug_selection_log('collapse', state)
+  end subroutine collapse_selection
+
+  ! Called AFTER a base movement handler has moved the cursor while
+  ! module_extending_selection is .true. Establishes a new selection anchored
+  ! at old_cursor_pos if one isn't already active, or extends the existing
+  ! one. If the motion brings cursor back to anchor, auto-collapses.
+  subroutine update_selection_on_shift_motion(state, old_cursor_pos)
+    type(input_state_t), intent(inout) :: state
+    integer, intent(in) :: old_cursor_pos
+
+    if (state%cursor_pos == old_cursor_pos) then
+      ! No actual motion occurred (e.g. Shift+Left at pos 0). Leave state alone.
+      return
+    end if
+
+    if (.not. state%selection_active) then
+      ! Starting a fresh selection — anchor at the position before this motion.
+      state%selection_anchor = old_cursor_pos
+      state%selection_active = .true.
+    end if
+
+    ! If the motion brought cursor back to anchor, the selection is empty — collapse.
+    if (state%selection_anchor == state%cursor_pos) then
+      call collapse_selection(state)
+    end if
+
+    ! Selection rendering needs a full redraw (Sprint 2 handles the highlight).
+    state%dirty = .true.
+    call debug_selection_log('extend', state)
+  end subroutine update_selection_on_shift_motion
+
+  ! Remove the selected byte range from the buffer, set cursor to the left
+  ! edge, and clear selection state. No-op if selection is not active.
+  ! Unused in Sprint 1 itself, but lands now for use in Sprint 3.
+  subroutine delete_selection(state)
+    type(input_state_t), intent(inout) :: state
+    integer :: sel_start, sel_end, span, i
+    character(len=MAX_LINE_LEN) :: temp_buf
+
+    if (.not. state%selection_active) return
+    if (state%selection_anchor < 0) then
+      ! Defensive: active flag set without an anchor; just clear state.
+      call collapse_selection(state)
+      return
+    end if
+
+    sel_start = min(state%selection_anchor, state%cursor_pos)
+    sel_end   = max(state%selection_anchor, state%cursor_pos)
+    span      = sel_end - sel_start
+
+    if (span <= 0) then
+      call collapse_selection(state)
+      return
+    end if
+
+    ! Read current buffer, shift bytes after sel_end leftward, rewrite.
+    call state_buffer_get(state, temp_buf)
+    do i = sel_end + 1, state%length
+      call state_buffer_set_char(state, i - span, temp_buf(i:i))
+    end do
+    ! Pad the now-unused tail so stale bytes don't leak on later reads.
+    do i = state%length - span + 1, state%length
+      call state_buffer_set_char(state, i, ' ')
+    end do
+
+    state%length     = state%length - span
+    state%cursor_pos = sel_start
+    state%dirty      = .true.
+    call collapse_selection(state)
+    call debug_selection_log('delete', state)
+  end subroutine delete_selection
+
+  !============================================================================
+  ! END TEXT SELECTION HELPERS
   !============================================================================
 
   ! Initialize input_state_t with allocated strings
@@ -2817,6 +2969,17 @@ contains
   subroutine move_to_next_word(input_state)
     type(input_state_t), intent(inout) :: input_state
     integer :: pos
+    integer :: old_cursor_pos
+
+    ! Plain word-motion with active selection: clear, then proceed from
+    ! current cursor. No snap — word motion runs through the old cursor
+    ! anyway (#25, #26).
+    if (input_state%selection_active .and. .not. module_extending_selection) then
+      call collapse_selection(input_state)
+      input_state%dirty = .true.
+    end if
+
+    old_cursor_pos = input_state%cursor_pos
 
     pos = input_state%cursor_pos + 1
 
@@ -2847,13 +3010,32 @@ contains
     end if
 
     input_state%dirty = .true.
+
+    if (module_extending_selection) then
+      call update_selection_on_shift_motion(input_state, old_cursor_pos)
+    end if
   end subroutine
 
   subroutine move_to_previous_word(input_state)
     type(input_state_t), intent(inout) :: input_state
     integer :: pos
-    
-    if (input_state%cursor_pos <= 0) return
+    integer :: old_cursor_pos
+
+    ! Plain word-motion with active selection: clear, then proceed from
+    ! current cursor (#25, #26).
+    if (input_state%selection_active .and. .not. module_extending_selection) then
+      call collapse_selection(input_state)
+      input_state%dirty = .true.
+    end if
+
+    old_cursor_pos = input_state%cursor_pos
+
+    if (input_state%cursor_pos <= 0) then
+      if (module_extending_selection) then
+        call update_selection_on_shift_motion(input_state, old_cursor_pos)
+      end if
+      return
+    end if
 
     pos = input_state%cursor_pos - 1
 
@@ -2872,6 +3054,10 @@ contains
     ! so space position is correct (cursor will be after space, before first char of word)
     input_state%cursor_pos = pos
     input_state%dirty = .true.
+
+    if (module_extending_selection) then
+      call update_selection_on_shift_motion(input_state, old_cursor_pos)
+    end if
   end subroutine
 
   subroutine delete_char_at_cursor(input_state)
@@ -5692,12 +5878,24 @@ contains
       case('b')
         ! Alt+b - Move backward one word
         call move_to_previous_word(input_state)
+      case('B')
+        ! Alt+Shift+b - Extend selection one word back (shift phase, Sprint 1)
+        ! ESC-uppercase is xterm's encoding for Alt+Shift+letter. Routes through
+        ! the shift-extending path so move_to_previous_word grows the selection.
+        module_extending_selection = .true.
+        call move_to_previous_word(input_state)
+        module_extending_selection = .false.
       case('d')
         ! Alt+d - Delete forward one word (emacs standard)
         call handle_kill_word_forward(input_state)
       case('f')
         ! Alt+f - Move forward one word
         call move_to_next_word(input_state)
+      case('F')
+        ! Alt+Shift+f - Extend selection one word forward (shift phase, Sprint 1)
+        module_extending_selection = .true.
+        call move_to_next_word(input_state)
+        module_extending_selection = .false.
       case('j')
         ! Alt+j - Jump to directory with fzf
         call launch_fzf_directory_browser(input_state)
@@ -5906,6 +6104,50 @@ contains
               input_state%suggestion_length > 0) then
             call accept_autosuggestion_word(input_state)
           end if
+        ! ============================================================
+        ! Shift-phase selection extension (modifiers 2 and 6)
+        ! Sprint 1: state only; Sprint 2 adds the visible highlight.
+        ! ============================================================
+        ! Shift+Left — extend selection one char back
+        else if (modifier == '2' .and. terminator == 'D') then
+          module_extending_selection = .true.
+          call handle_cursor_left(input_state)
+          module_extending_selection = .false.
+        ! Shift+Right — extend selection one char forward
+        else if (modifier == '2' .and. terminator == 'C') then
+          module_extending_selection = .true.
+          call handle_cursor_right(input_state)
+          module_extending_selection = .false.
+        ! Shift+Up — treat as Shift+Home on single-line prompt (#25)
+        else if (modifier == '2' .and. terminator == 'A') then
+          module_extending_selection = .true.
+          call handle_home(input_state)
+          module_extending_selection = .false.
+        ! Shift+Down — treat as Shift+End on single-line prompt (#25)
+        else if (modifier == '2' .and. terminator == 'B') then
+          module_extending_selection = .true.
+          call handle_end(input_state)
+          module_extending_selection = .false.
+        ! Shift+Home — extend selection to start of line
+        else if (modifier == '2' .and. terminator == 'H') then
+          module_extending_selection = .true.
+          call handle_home(input_state)
+          module_extending_selection = .false.
+        ! Shift+End — extend selection to end of line
+        else if (modifier == '2' .and. terminator == 'F') then
+          module_extending_selection = .true.
+          call handle_end(input_state)
+          module_extending_selection = .false.
+        ! Ctrl+Shift+Left — extend selection by one word back
+        else if (modifier == '6' .and. terminator == 'D') then
+          module_extending_selection = .true.
+          call move_to_previous_word(input_state)
+          module_extending_selection = .false.
+        ! Ctrl+Shift+Right — extend selection by one word forward
+        else if (modifier == '6' .and. terminator == 'C') then
+          module_extending_selection = .true.
+          call move_to_next_word(input_state)
+          module_extending_selection = .false.
         ! Check for Alt+Left/Right for word movement (modifier=3)
         else if (modifier == '3' .and. terminator == 'D') then
           ! Alt+Left - Move cursor backward one word (standard behavior)
@@ -5963,8 +6205,22 @@ contains
     type(input_state_t), intent(inout) :: input_state
     integer :: old_row, old_col, new_row, new_col, term_cols
     integer :: bytes_to_move
+    integer :: old_cursor_pos
     logical :: debug_utf8
     integer :: debug_stat
+
+    ! Shift-phase: plain Left with an active selection snaps cursor to the
+    ! LEFT edge and clears selection, without further motion (#25, #26).
+    ! Char-motion uses the snap-to-edge convention (matches VS Code/TextEdit).
+    if (input_state%selection_active .and. .not. module_extending_selection) then
+      input_state%cursor_pos = min(input_state%selection_anchor, input_state%cursor_pos)
+      call collapse_selection(input_state)
+      input_state%dirty = .true.
+      return
+    end if
+
+    ! Capture pre-motion cursor so shift-extending can anchor the selection.
+    old_cursor_pos = input_state%cursor_pos
 
     ! Check if UTF-8 debug mode is enabled
     call get_environment_variable('FORTSH_DEBUG_UTF8', status=debug_stat)
@@ -6010,12 +6266,32 @@ contains
       module_cursor_screen_row = new_row
       module_cursor_screen_col = new_col
     end if
+
+    ! Shift-phase: if this call is extending a selection, update it now.
+    if (module_extending_selection) then
+      call update_selection_on_shift_motion(input_state, old_cursor_pos)
+    end if
   end subroutine
-  
+
   subroutine handle_cursor_right(input_state)
     type(input_state_t), intent(inout) :: input_state
     integer :: old_row, old_col, new_row, new_col, term_cols
     integer :: bytes_to_move
+    integer :: old_cursor_pos
+
+    ! Shift-phase: plain Right with an active selection snaps cursor to the
+    ! RIGHT edge and clears selection, without further motion (#25, #26).
+    if (input_state%selection_active .and. .not. module_extending_selection) then
+      input_state%cursor_pos = max(input_state%selection_anchor, input_state%cursor_pos)
+      if (input_state%cursor_pos > input_state%length) then
+        input_state%cursor_pos = input_state%length
+      end if
+      call collapse_selection(input_state)
+      input_state%dirty = .true.
+      return
+    end if
+
+    old_cursor_pos = input_state%cursor_pos
 
     if (input_state%cursor_pos < input_state%length) then
       ! Get terminal size
@@ -6047,16 +6323,27 @@ contains
       ! Update module cursor tracking
       module_cursor_screen_row = new_row
       module_cursor_screen_col = new_col
-    else if (input_state%cursor_pos == input_state%length .and. input_state%suggestion_length > 0) then
-      ! At end of line with suggestion - accept it
+    else if (input_state%cursor_pos == input_state%length .and. input_state%suggestion_length > 0 &
+             .and. .not. module_extending_selection) then
+      ! At end of line with suggestion - accept it (but not during shift-extension —
+      ! Shift+Right at the end of the line should not eat an autosuggestion).
       call accept_autosuggestion(input_state)
     end if
+
+    ! Shift-phase: if this call is extending a selection, update it now.
+    if (module_extending_selection) then
+      call update_selection_on_shift_motion(input_state, old_cursor_pos)
+    end if
   end subroutine
-  
+
   subroutine handle_history_up(input_state)
     type(input_state_t), intent(inout) :: input_state
     character(len=MAX_LINE_LEN) :: history_line
     logical :: found
+
+    ! History navigation replaces the buffer wholesale — selection byte
+    ! offsets from the old buffer would point into stale data (#27).
+    if (input_state%selection_active) call collapse_selection(input_state)
 
     ! If there's text on the line and we're not yet in any history mode,
     ! enter prefix search mode (fish-style)
@@ -6103,6 +6390,9 @@ contains
     type(input_state_t), intent(inout) :: input_state
     character(len=MAX_LINE_LEN) :: history_line
     logical :: found
+
+    ! Buffer replacement — clear any stale selection (#27).
+    if (input_state%selection_active) call collapse_selection(input_state)
 
     ! Prefix search: find next match or return to present
     if (input_state%in_prefix_search) then
@@ -6733,6 +7023,17 @@ contains
   ! Advanced line editing functions for Phase 5
   subroutine handle_home(input_state)
     type(input_state_t), intent(inout) :: input_state
+    integer :: old_cursor_pos
+
+    ! Plain motion with active selection: clear selection, then proceed with
+    ! normal motion. Home/End don't snap — they always go to 0/length — so a
+    ! simple clear is correct (#25, #26).
+    if (input_state%selection_active .and. .not. module_extending_selection) then
+      call collapse_selection(input_state)
+      input_state%dirty = .true.
+    end if
+
+    old_cursor_pos = input_state%cursor_pos
 
     ! Move cursor to beginning of line
     if (input_state%cursor_pos > 0) then
@@ -6740,16 +7041,32 @@ contains
       ! Mark dirty to trigger full redraw with correct cursor position
       input_state%dirty = .true.
     end if
+
+    if (module_extending_selection) then
+      call update_selection_on_shift_motion(input_state, old_cursor_pos)
+    end if
   end subroutine
-  
+
   subroutine handle_end(input_state)
     type(input_state_t), intent(inout) :: input_state
+    integer :: old_cursor_pos
+
+    if (input_state%selection_active .and. .not. module_extending_selection) then
+      call collapse_selection(input_state)
+      input_state%dirty = .true.
+    end if
+
+    old_cursor_pos = input_state%cursor_pos
 
     ! Move cursor to end of line
     if (input_state%cursor_pos < input_state%length) then
       input_state%cursor_pos = input_state%length
       ! Mark dirty to trigger full redraw with correct cursor position
       input_state%dirty = .true.
+    end if
+
+    if (module_extending_selection) then
+      call update_selection_on_shift_motion(input_state, old_cursor_pos)
     end if
   end subroutine
   
@@ -7252,6 +7569,9 @@ contains
     logical, intent(inout) :: done
     character(len=5) :: cmd
 
+    ! Buffer replacement — clear any stale selection (#27).
+    if (input_state%selection_active) call collapse_selection(input_state)
+
     cmd = 'cd ..'
 
     ! Clear current buffer and insert "cd .."
@@ -7279,6 +7599,8 @@ contains
     logical, intent(inout) :: done
     character(len=5) :: cmd
 
+    if (input_state%selection_active) call collapse_selection(input_state)
+
     cmd = 'prevd'
 
     ! Clear current buffer and insert "prevd"
@@ -7305,6 +7627,8 @@ contains
     type(input_state_t), intent(inout) :: input_state
     logical, intent(inout) :: done
     character(len=5) :: cmd
+
+    if (input_state%selection_active) call collapse_selection(input_state)
 
     cmd = 'nextd'
 
@@ -8242,6 +8566,9 @@ contains
 
     if (input_state%suggestion_length == 0) return
 
+    ! Buffer is about to be extended — any lingering selection is stale (#27).
+    if (input_state%selection_active) call collapse_selection(input_state)
+
     ! Safety check: ensure we won't overflow
     new_length = input_state%length + input_state%suggestion_length
     if (new_length > MAX_LINE_LEN) then
@@ -8268,6 +8595,9 @@ contains
     integer :: i, word_end
 
     if (input_state%suggestion_length == 0) return
+
+    ! Buffer is about to be extended — any lingering selection is stale (#27).
+    if (input_state%selection_active) call collapse_selection(input_state)
 
     ! Find the end of the first word in the suggestion
     word_end = 0

--- a/src/io/readline.f90
+++ b/src/io/readline.f90
@@ -278,6 +278,16 @@ module readline
   logical, save :: debug_selection = .false.
   logical, save :: debug_selection_initialized = .false.
 
+  ! Clipboard bridge state (shift phase, Sprint 5).
+  ! Probed once at init; the detected tool is cached. Pattern #19.
+  integer, parameter :: CLIP_NONE   = 0
+  integer, parameter :: CLIP_PBCOPY = 1  ! macOS
+  integer, parameter :: CLIP_WLCOPY = 2  ! Wayland
+  integer, parameter :: CLIP_XCLIP  = 3  ! X11
+  integer, parameter :: CLIP_XSEL   = 4  ! X11 fallback
+  integer, save :: clipboard_tool = CLIP_NONE
+  logical, save :: clipboard_initialized = .false.
+
 contains
 
   !============================================================================
@@ -770,6 +780,135 @@ contains
   ! END TEXT SELECTION HELPERS
   !============================================================================
 
+  !============================================================================
+  ! CLIPBOARD BRIDGE (shift phase, Sprint 5)
+  !============================================================================
+  ! Provides system-clipboard copy and paste via external tools.
+  ! Probe order: pbcopy (macOS), wl-copy (Wayland), xclip (X11), xsel (X11).
+  ! If no tool is found, operations no-op gracefully — the in-session
+  ! kill_buffer remains the source of truth. Pattern #19, #22.
+  !============================================================================
+
+  ! Detect the clipboard tool at startup (idempotent).
+  subroutine clipboard_detect()
+    character(len=:), allocatable :: result
+
+    if (clipboard_initialized) return
+    clipboard_initialized = .true.
+
+    ! Probe in preference order. execute_and_capture runs `which <tool>`
+    ! and returns the path if found, or an empty string if not.
+    result = execute_and_capture('which pbcopy 2>/dev/null')
+    if (len_trim(result) > 0) then
+      clipboard_tool = CLIP_PBCOPY
+      return
+    end if
+
+    result = execute_and_capture('which wl-copy 2>/dev/null')
+    if (len_trim(result) > 0) then
+      clipboard_tool = CLIP_WLCOPY
+      return
+    end if
+
+    result = execute_and_capture('which xclip 2>/dev/null')
+    if (len_trim(result) > 0) then
+      clipboard_tool = CLIP_XCLIP
+      return
+    end if
+
+    result = execute_and_capture('which xsel 2>/dev/null')
+    if (len_trim(result) > 0) then
+      clipboard_tool = CLIP_XSEL
+      return
+    end if
+
+    ! No tool found — clipboard_tool stays CLIP_NONE.
+  end subroutine clipboard_detect
+
+  ! Copy text to the system clipboard. No-op if no tool was detected.
+  subroutine clipboard_copy(text, text_len)
+    use iso_c_binding, only: c_ptr, c_null_char, c_loc, c_int, c_associated
+    character(len=*), intent(in) :: text
+    integer, intent(in) :: text_len
+    type(c_ptr) :: pipe_ptr
+    integer(c_int) :: rc
+    character(len=256), target :: c_command
+    character(len=4), target :: c_mode
+    ! Buffer for writing — must be null-terminated for c_fputs.
+    ! Use MAX_LINE_LEN+1 to accommodate the NUL terminator.
+    character(len=MAX_LINE_LEN+1), target :: c_text
+
+    if (.not. clipboard_initialized) call clipboard_detect()
+    if (clipboard_tool == CLIP_NONE) return
+    if (text_len <= 0) return
+
+    ! Build the popen command for the detected tool.
+    select case (clipboard_tool)
+    case (CLIP_PBCOPY)
+      c_command = 'pbcopy' // c_null_char
+    case (CLIP_WLCOPY)
+      c_command = 'wl-copy' // c_null_char
+    case (CLIP_XCLIP)
+      c_command = 'xclip -selection clipboard' // c_null_char
+    case (CLIP_XSEL)
+      c_command = 'xsel --clipboard --input' // c_null_char
+    case default
+      return
+    end select
+
+    c_mode = 'w' // c_null_char
+
+    pipe_ptr = c_popen(c_loc(c_command), c_loc(c_mode))
+    if (.not. c_associated(pipe_ptr)) return
+
+    ! Write the text, null-terminated, to the pipe.
+    c_text = text(1:text_len) // c_null_char
+    rc = c_fputs(c_loc(c_text), pipe_ptr)
+
+    rc = c_pclose(pipe_ptr)
+  end subroutine clipboard_copy
+
+  ! Paste text from the system clipboard into a buffer.
+  ! Returns the number of bytes read (0 if no tool or empty clipboard).
+  subroutine clipboard_paste(buffer, buffer_len, bytes_read)
+    character(len=*), intent(out) :: buffer
+    integer, intent(in) :: buffer_len
+    integer, intent(out) :: bytes_read
+    character(len=:), allocatable :: result
+    character(len=256) :: paste_cmd
+
+    bytes_read = 0
+
+    if (.not. clipboard_initialized) call clipboard_detect()
+    if (clipboard_tool == CLIP_NONE) return
+
+    ! Build the paste command.
+    select case (clipboard_tool)
+    case (CLIP_PBCOPY)
+      paste_cmd = 'pbpaste -Prefer txt 2>/dev/null'
+    case (CLIP_WLCOPY)
+      paste_cmd = 'wl-paste --no-newline 2>/dev/null'
+    case (CLIP_XCLIP)
+      paste_cmd = 'xclip -selection clipboard -o 2>/dev/null'
+    case (CLIP_XSEL)
+      paste_cmd = 'xsel --clipboard --output 2>/dev/null'
+    case default
+      return
+    end select
+
+    result = execute_and_capture(trim(paste_cmd))
+    if (.not. allocated(result)) return
+    if (len_trim(result) == 0) return
+
+    bytes_read = min(len_trim(result), buffer_len)
+    buffer = ''
+    buffer(1:bytes_read) = result(1:bytes_read)
+  end subroutine clipboard_paste
+
+  !============================================================================
+  ! END CLIPBOARD BRIDGE
+  !============================================================================
+
   ! Initialize input_state_t with allocated strings
   subroutine init_input_state(state)
     type(input_state_t), intent(inout) :: state
@@ -1195,6 +1334,8 @@ contains
       call init_input_state(module_input_state)
       ! Initialize syntax highlighting
       call init_syntax_highlighting()
+      ! Probe for system clipboard tool (Sprint 5 — pattern #19: once at init)
+      call clipboard_detect()
       module_input_state_initialized = .true.
     else
       ! On subsequent calls, just reset the buffer and cursor

--- a/src/io/readline.f90
+++ b/src/io/readline.f90
@@ -6097,6 +6097,20 @@ contains
         ! Extended escape sequence (e.g., Ctrl+Arrow = ESC[1;5C) or simple (ESC[3~)
         if (input_state%in_prefix_search) call cancel_prefix_search(input_state)
         call handle_extended_escape_sequence(input_state, done, ch2)
+      case('H')  ! Home key (VT100/ANSI encoding; tilde variant ESC[1~ in extended handler)
+        if (input_state%in_search) then
+          call accept_search_for_editing(input_state)
+        else
+          if (input_state%in_prefix_search) call cancel_prefix_search(input_state)
+          call handle_home(input_state)
+        end if
+      case('F')  ! End key (VT100/ANSI encoding; tilde variant ESC[4~ in extended handler)
+        if (input_state%in_search) then
+          call accept_search_for_editing(input_state)
+        else
+          if (input_state%in_prefix_search) call cancel_prefix_search(input_state)
+          call handle_end(input_state)
+        end if
       case default
         ! Unknown escape sequence - ignore it
         continue

--- a/src/io/readline.f90
+++ b/src/io/readline.f90
@@ -47,6 +47,7 @@ module readline
   integer, parameter :: KEY_TAB = 9
   integer, parameter :: KEY_CTRL_C = 3
   integer, parameter :: KEY_CTRL_D = 4
+  integer, parameter :: KEY_CTRL_V = 22   ! Paste from system clipboard / kill buffer
   integer, parameter :: KEY_CTRL_X = 24   ! Process kill mode
   integer, parameter :: KEY_CTRL_A = 1    ! Home (beginning of line)
   integer, parameter :: KEY_CTRL_E = 5    ! End (end of line)
@@ -1673,6 +1674,13 @@ contains
             call handle_kill_word(module_input_state)
           end if
           
+        case(KEY_CTRL_V)
+          ! Ctrl+V — paste (Sprint 5). Reads from the system clipboard
+          ! first; falls back to the in-session kill_buffer if no
+          ! clipboard tool is available or the clipboard is empty.
+          ! If a selection is active, it's deleted first (paste-over).
+          if (.not. module_input_state%in_search) call handle_paste(module_input_state)
+
         case(KEY_CTRL_Y)
           ! Yank - no-op in search mode
           if (.not. module_input_state%in_search) call handle_yank(module_input_state)
@@ -7514,7 +7522,49 @@ contains
     input_state%cursor_pos = input_state%cursor_pos + insert_len
     input_state%dirty = .true.
   end subroutine
-  
+
+  ! Ctrl+V paste handler (Sprint 5). Reads from the system clipboard;
+  ! if the clipboard is empty or no tool is available, falls back to
+  ! yanking from the in-session kill_buffer. If a selection is active
+  ! it is deleted first (paste-over behavior, same as Ctrl+Y).
+  subroutine handle_paste(input_state)
+    type(input_state_t), intent(inout) :: input_state
+    character(len=MAX_LINE_LEN) :: paste_buf
+    integer :: paste_len, insert_len, i, j
+
+    ! Delete active selection first (paste-over).
+    if (input_state%selection_active) call delete_selection(input_state)
+
+    ! Try the system clipboard.
+    paste_len = 0
+    call clipboard_paste(paste_buf, MAX_LINE_LEN, paste_len)
+
+    if (paste_len > 0) then
+      ! Truncate to available space.
+      insert_len = min(paste_len, MAX_LINE_LEN - input_state%length)
+      if (insert_len <= 0) return
+
+      ! Shift existing text right.
+      do i = input_state%length, input_state%cursor_pos + 1, -1
+        if (i + insert_len <= MAX_LINE_LEN) then
+          call state_buffer_set_char(input_state, i + insert_len, state_buffer_get_char(input_state, i))
+        end if
+      end do
+
+      ! Insert clipboard text at cursor.
+      do j = 1, insert_len
+        call state_buffer_set_char(input_state, input_state%cursor_pos + j, paste_buf(j:j))
+      end do
+
+      input_state%length = input_state%length + insert_len
+      input_state%cursor_pos = input_state%cursor_pos + insert_len
+      input_state%dirty = .true.
+    else
+      ! Clipboard empty or unavailable — fall back to kill buffer (same as C-y).
+      call handle_yank(input_state)
+    end if
+  end subroutine handle_paste
+
   subroutine handle_clear_screen(input_state, prompt)
     type(input_state_t), intent(inout) :: input_state
     character(len=*), intent(in) :: prompt

--- a/src/io/readline.f90
+++ b/src/io/readline.f90
@@ -732,6 +732,10 @@ contains
     call state_buffer_get(state, temp_buf)
     call state_kill_buffer_set(state, temp_buf(sel_start+1:sel_end))
     state%kill_length = span
+
+    ! Sprint 5: also write to system clipboard (no-op if no tool detected).
+    call clipboard_copy(temp_buf(sel_start+1:sel_end), span)
+
     call debug_selection_log('copy-to-kill', state)
   end subroutine copy_selection_to_kill_buffer
 

--- a/src/io/readline.f90
+++ b/src/io/readline.f90
@@ -48,7 +48,7 @@ module readline
   integer, parameter :: KEY_CTRL_C = 3
   integer, parameter :: KEY_CTRL_D = 4
   integer, parameter :: KEY_CTRL_V = 22   ! Paste from system clipboard / kill buffer
-  integer, parameter :: KEY_CTRL_X = 24   ! Process kill mode
+  integer, parameter :: KEY_CTRL_X = 24   ! Cut selection / Process kill mode
   integer, parameter :: KEY_CTRL_A = 1    ! Home (beginning of line)
   integer, parameter :: KEY_CTRL_E = 5    ! End (end of line)
   integer, parameter :: KEY_CTRL_K = 11   ! Kill to end of line
@@ -1576,8 +1576,15 @@ contains
           done = .true.
 
         case(KEY_CTRL_X)
-          ! Ctrl+X - Enter process kill mode (no-op in search mode)
-          if (.not. module_input_state%in_search .and. &
+          ! Ctrl+X — dual-mode (Sprint 5):
+          !   1. If a selection is active, CUT (same as Ctrl+W on selection:
+          !      copy to kill buffer + system clipboard, then delete range).
+          !   2. Otherwise, enter process kill mode (existing behavior).
+          if (module_input_state%selection_active) then
+            call copy_selection_to_kill_buffer(module_input_state)
+            call delete_selection(module_input_state)
+            call update_autosuggestion(module_input_state)
+          else if (.not. module_input_state%in_search .and. &
               .not. module_input_state%in_process_kill_mode) then
             call enter_process_kill_mode(module_input_state)
           end if

--- a/src/system/interface.f90
+++ b/src/system/interface.f90
@@ -450,7 +450,16 @@ module system_interface
       type(c_ptr), value :: stream
       type(c_ptr) :: c_fgets
     end function
-    
+
+    ! Write a null-terminated string to a stream (shift phase Sprint 5:
+    ! used to pipe text into clipboard tools like pbcopy via popen("w")).
+    function c_fputs(s, stream) bind(C, name="fputs")
+      import :: c_ptr, c_int
+      type(c_ptr), value :: s
+      type(c_ptr), value :: stream
+      integer(c_int) :: c_fputs
+    end function
+
     subroutine c_exit(status) bind(C, name="exit")
       import :: c_int
       integer(c_int), value :: status

--- a/src/system/interface.f90
+++ b/src/system/interface.f90
@@ -1091,12 +1091,23 @@ contains
     ! Assign to result variable at the very end
     success = mode_ok
 
-    ! Enable bracketed paste mode (if raw mode succeeded)
+    ! Enable bracketed paste mode (if raw mode succeeded).
+    ! FORTSH_NO_BRACKETED_PASTE=1 disables the emit — a kill switch for
+    ! bug triage on terminals that mishandle the mode (pattern #20).
     if (success) then
-      ! ESC[?2004h = Enable bracketed paste
-      ! Terminal will wrap pasted text in ESC[200~ ... ESC[201~
-      write(output_unit, '(A)', advance='no') char(27) // '[?2004h'
-      flush(output_unit)
+      block
+        character(len=8) :: no_bp_env
+        integer :: bp_stat
+        logical :: bp_disabled
+        call get_environment_variable('FORTSH_NO_BRACKETED_PASTE', no_bp_env, status=bp_stat)
+        bp_disabled = (bp_stat == 0 .and. trim(no_bp_env) == '1')
+        if (.not. bp_disabled) then
+          ! ESC[?2004h = Enable bracketed paste
+          ! Terminal will wrap pasted text in ESC[200~ ... ESC[201~
+          write(output_unit, '(A)', advance='no') char(27) // '[?2004h'
+          flush(output_unit)
+        end if
+      end block
 
       ! Debug: Check if FORTSH_DEBUG_PASTE is set
       block
@@ -1120,11 +1131,19 @@ contains
     type(termios_t), intent(in) :: original_termios
     logical :: success
     integer :: ret
+    character(len=8) :: no_bp_env
+    integer :: bp_stat
+    logical :: bp_disabled
 
-    ! Disable bracketed paste mode before restoring terminal
-    ! ESC[?2004l = Disable bracketed paste
-    write(output_unit, '(A)', advance='no') char(27) // '[?2004l'
-    flush(output_unit)
+    ! Disable bracketed paste mode before restoring terminal,
+    ! unless FORTSH_NO_BRACKETED_PASTE=1 (we never enabled it).
+    call get_environment_variable('FORTSH_NO_BRACKETED_PASTE', no_bp_env, status=bp_stat)
+    bp_disabled = (bp_stat == 0 .and. trim(no_bp_env) == '1')
+    if (.not. bp_disabled) then
+      ! ESC[?2004l = Disable bracketed paste
+      write(output_unit, '(A)', advance='no') char(27) // '[?2004l'
+      flush(output_unit)
+    end if
 
     ret = c_tcsetattr(STDIN_FD, TCSANOW, original_termios)
     success = (ret == 0)

--- a/tests/interactive/test_specs/selection.yaml
+++ b/tests/interactive/test_specs/selection.yaml
@@ -487,3 +487,56 @@ tests:
       - send_key: "Enter"
     expect_output: "abc"
     match_type: "contains"
+
+  # =============================================================
+  # SPRINT 5 — CLIPBOARD BRIDGE + CTRL+X / CTRL+V
+  # These tests run outside test mode so clipboard tools are
+  # accessible (test mode doesn't affect clipboard, but we need
+  # FORTSH_TEST_MODE=0 for full redraw + echo output assertions).
+  # =============================================================
+
+  - name: "Sprint 5: Ctrl+X on selection cuts (dual-mode)"
+    # Select "bbb", Ctrl+X cuts it. Buffer becomes "aaa  ccc".
+    # (The trailing space after "aaa" was between "aaa" and "bbb".)
+    # Then type "Z" where cursor is → "aaa Z ccc".
+    steps:
+      - send: "aaa bbb ccc"
+      - send_key: "C-S-Left"
+      - send_key: "C-S-Left"
+      - send_key: "C-x"
+      - send: "Z"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    # C-S-Left from 11 → word back to 8 (start of "ccc"), again to 4 (start of "bbb").
+    # Selection = [4..11) = "bbb ccc". After Ctrl+X delete: buffer "aaa ", cursor=4.
+    # Insert Z → "aaa Z", cursor=5. Echo → "aaa Z".
+    expect_output: "aaa Z"
+    match_type: "contains"
+
+  - name: "Sprint 5: Ctrl+X with no selection enters process kill mode"
+    # Regression guard: Ctrl+X without selection must NOT cut anything.
+    # It enters process-kill-mode (the existing behavior). Pressing
+    # Escape exits process-kill mode. Then normal editing resumes.
+    steps:
+      - send: "echo intact"
+      - send_key: "C-x"
+      - send_key: "Escape"
+      - send_key: "Enter"
+    expect_output: "intact"
+    match_type: "contains"
+
+  - name: "Sprint 5: Ctrl+V pastes from kill buffer when no clipboard"
+    # Populate kill buffer via Ctrl+U, then Ctrl+V to paste. Since the
+    # PTY test harness runs in test mode with a clean env, Ctrl+V reads
+    # the system clipboard (which may contain stale data from earlier
+    # tests). Instead we verify the kill-buffer fallback: Ctrl+U kills
+    # "hello", Ctrl+V pastes it back.
+    steps:
+      - send: "hello"
+      - send_key: "C-u"
+      - send: "echo "
+      - send_key: "C-v"
+      - send_key: "Enter"
+    expect_output: "hello"
+    match_type: "contains"

--- a/tests/interactive/test_specs/selection.yaml
+++ b/tests/interactive/test_specs/selection.yaml
@@ -271,3 +271,70 @@ tests:
       - send_line: "pwd"
     expect_output: "/"
     match_type: "contains"
+
+  # =============================================================
+  # SPRINT 2 — VISIBLE RENDERING
+  # These tests force FORTSH_TEST_MODE off so the full redraw path
+  # runs and emits reverse-video ANSI codes (ESC[7m ... ESC[27m)
+  # around the selected byte range. Each test uses fresh_session to
+  # avoid polluting adjacent tests with redraw noise.
+  # =============================================================
+
+  - name: "Sprint 2: Shift+Left emits reverse-video around selection"
+    # After "echo hello world" + 5x Shift+Left, the rendering should
+    # include the literal sequence ESC[7m followed by "world" followed
+    # by ESC[27m. pexpect matches on regex, so we escape the [.
+    env:
+      FORTSH_TEST_MODE: "0"
+    fresh_session: true
+    steps:
+      - send: "echo hello world"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+    expect_output: "\u001b\\[7mworld\u001b\\[27m"
+
+  - name: "Sprint 2: Shift+Home highlights to start of line"
+    # "abcd" + Shift+Home → anchor=4, cursor=0. Render has prefix empty,
+    # reverse-video "abcd", suffix empty.
+    env:
+      FORTSH_TEST_MODE: "0"
+    fresh_session: true
+    steps:
+      - send: "abcd"
+      - send_key: "S-Home"
+    expect_output: "\u001b\\[7mabcd\u001b\\[27m"
+
+  - name: "Sprint 2: Ctrl+Shift+Left highlights one word back"
+    # "aaa bbb" + C-S-Left → anchor=7, cursor=4. Render has prefix
+    # "aaa ", reverse-video "bbb", suffix empty.
+    env:
+      FORTSH_TEST_MODE: "0"
+    fresh_session: true
+    steps:
+      - send: "aaa bbb"
+      - send_key: "C-S-Left"
+    expect_output: "\u001b\\[7mbbb\u001b\\[27m"
+
+  - name: "Sprint 2: plain Left after selection collapses — no ESC[7m in tail"
+    # Select, then plain Left (snaps to left edge, collapses). The
+    # NEXT redraw must NOT contain reverse video. We verify by sending
+    # more chars and expecting them NOT to be wrapped in ESC[7m.
+    # Use 'expect_not' to check absence of reverse video on the suffix.
+    env:
+      FORTSH_TEST_MODE: "0"
+    fresh_session: true
+    steps:
+      - send: "abcd"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "Left"
+      - send: "Z"
+    # After Left, selection collapses (cursor=2, snapped to min edge).
+    # Inserting Z goes at pos 2 → "abZcd". The final redraw should show
+    # the buffer plain (no reverse video around Z). Assert on presence
+    # of "abZcd" text in the stream — if selection incorrectly persisted,
+    # the render would wrap bytes in ESC[7m instead.
+    expect_output: "abZcd"

--- a/tests/interactive/test_specs/selection.yaml
+++ b/tests/interactive/test_specs/selection.yaml
@@ -338,3 +338,152 @@ tests:
     # of "abZcd" text in the stream — if selection incorrectly persisted,
     # the render would wrap bytes in ESC[7m instead.
     expect_output: "abZcd"
+
+  # =============================================================
+  # SPRINT 3 — SELECTION-AWARE EDITING
+  # Type-over, backspace/delete, Ctrl+W cut, Alt+W copy, Ctrl+Y yank.
+  # All go through the delete_selection / copy_selection_to_kill_buffer
+  # helpers that landed in Sprint 1. Tests run in default test mode —
+  # they assert on the buffer state after executing `echo <final>`.
+  # =============================================================
+
+  - name: "Sprint 3: typing over selection replaces it"
+    # "echo hello world" → Shift+Left x5 moves cursor from 16 to 11,
+    # selecting bytes [11..16) = "world" (NOT the preceding space at 10).
+    # Type 'X' → delete_selection removes "world", insert X at 11 →
+    # buffer "echo hello X". Enter executes.
+    steps:
+      - send: "echo hello world"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send: "X"
+      - send_key: "Enter"
+    expect_output: "hello X"
+    match_type: "contains"
+
+  - name: "Sprint 3: Backspace on selection deletes the whole range"
+    # "echo hello world" → select "world" with 5x Shift+Left → Backspace
+    # removes the 5 chars → buffer "echo hello ". Execute → "hello "
+    # (echo trims trailing whitespace in word split so visible is "hello").
+    steps:
+      - send: "echo hello world"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "Backspace"
+      - send_key: "Enter"
+    expect_output: "hello"
+    match_type: "contains"
+
+  - name: "Sprint 3: Delete on selection also removes the whole range"
+    steps:
+      - send: "echo hello world"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "Delete"
+      - send_key: "Enter"
+    expect_output: "hello"
+    match_type: "contains"
+
+  - name: "Sprint 3: Ctrl+W on selection cuts to kill buffer"
+    # Select "world", Ctrl+W cuts → buffer "echo hello ". Move to start
+    # with C-a, yank with C-y → buffer "worldecho hello ".
+    steps:
+      - send: "echo hello world"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "C-w"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "C-y"
+      - send_key: "Enter"
+    expect_output: "world"
+    match_type: "contains"
+
+  - name: "Sprint 3: Alt+W on selection copies without deleting"
+    # Select "world", Alt+W copies to kill buffer (selection collapses,
+    # buffer intact). Move to end with C-e, space, Ctrl+Y yanks "world"
+    # at end → buffer "echo hello world world".
+    steps:
+      - send: "echo hello world"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "M-w"
+      - send_key: "C-e"
+      - send: " "
+      - send_key: "C-y"
+      - send_key: "Enter"
+    expect_output: "hello world world"
+    match_type: "contains"
+
+  - name: "Sprint 3: Ctrl+Y yanks into active selection (paste-over)"
+    # First populate the kill buffer: Ctrl+U kills "first" into kill buf.
+    # Then on the real line, select "world" (bytes [11..16)) and Ctrl+Y —
+    # selection is deleted and "first" is pasted in its place.
+    # Result: "echo hello first" → echo outputs "hello first".
+    steps:
+      - send: "first"
+      - send_key: "C-u"    # kill whole line into kill buffer
+      - send: "echo hello world"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "C-y"
+      - send_key: "Enter"
+    expect_output: "hello first"
+    match_type: "contains"
+
+  - name: "Sprint 3: typing over selection works mid-buffer"
+    # Select "bbb" via M-B, type 'Z' → "aaa Zccc".
+    # (This also verifies word-wise selection + type-over together.)
+    steps:
+      - send: "aaa bbb ccc"
+      - send_key: "M-b"    # move to start of "ccc" (Alt+b, no shift)
+      - send_key: "M-B"    # select "bbb " wait — M-B extends from end of bbb backward
+      - send: "Z"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    # Trace: cursor at 11 (end). Alt+b → move to start of "ccc" (pos 8).
+    # Alt+Shift+B extends word back → selection covers "ccc" wait no, M-B
+    # moves from 8 backwards to start of "bbb" (pos 4). anchor=8, cursor=4.
+    # Type 'Z': delete_selection removes bytes [4..8) = "bbb ", cursor=4.
+    # Insert Z at 4 → "aaa Zccc". C-a, echo, Enter → "aaa Zccc".
+    expect_output: "aaa Zccc"
+    match_type: "contains"
+
+  - name: "Sprint 3: Ctrl+W with no selection still kills word backward"
+    # Regression guard: Ctrl+W with no selection runs existing kill-word.
+    steps:
+      - send: "echo aaa bbb"
+      - send_key: "C-w"    # kill "bbb"
+      - send: "zzz"
+      - send_key: "Enter"
+    expect_output: "aaa zzz"
+    match_type: "contains"
+
+  - name: "Sprint 3: Backspace with no selection still deletes one char"
+    steps:
+      - send: "abcd"
+      - send_key: "Backspace"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "abc"
+    match_type: "contains"

--- a/tests/interactive/test_specs/selection.yaml
+++ b/tests/interactive/test_specs/selection.yaml
@@ -1,0 +1,273 @@
+# Text Selection Tests for fortsh
+# shift phase, Sprint 1: selection state + shift/ctrl-shift arrow dispatch.
+#
+# Sprint 1 does NOT render the selection visually (that's Sprint 2). These
+# tests assert BEHAVIORAL differences through subsequent text operations:
+#
+# - Plain Left/Right with an active selection SNAPS cursor to the selection
+#   edge (not a single-char step). A follow-up character insert lands at
+#   the edge position — observably different from a baseline fortsh.
+#
+# - Ctrl+Shift+Left/Right and Alt+Shift+B/F extend selection by a whole
+#   word. A subsequent plain motion + insert reveals where the selection
+#   edge was.
+#
+# Assertion strategy: build a final buffer, prepend `echo `, hit Enter, and
+# match on the echoed output. Echo word-splits trailing whitespace, so
+# expected strings are trimmed-right.
+
+metadata:
+  category: "Text Selection"
+  description: "Shift+Arrow selection state + dispatch (shift phase)"
+  phase: "shift/sprint-1"
+
+tests:
+  # =============================================================
+  # SHIFT+LEFT / SHIFT+RIGHT: char-wise extension + snap collapse
+  # =============================================================
+
+  - name: "Shift+Left extends; plain Right snaps to right edge"
+    # Type abcd, Shift+Left x2 (anchor=4, cursor=2), plain Right snaps
+    # cursor to max(4,2)=4, insert X at 4 → "abcdX".
+    # Baseline: Shift+Left treated as plain Left x2 → cursor=2; plain
+    # Right → cursor=3; X at 3 → "abcXd".
+    steps:
+      - send: "abcd"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "Right"
+      - send: "X"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "abcdX"
+    match_type: "contains"
+
+  - name: "Shift+Right extends; plain Left snaps to left edge"
+    # Type abcd, C-a (cursor=0), Shift+Right x2 (anchor=0, cursor=2),
+    # plain Left snaps to min(0,2)=0, insert X at 0 → "Xabcd".
+    # Baseline: Shift+Right → cursor=2; plain Left → cursor=1; X at 1 → "aXbcd".
+    steps:
+      - send: "abcd"
+      - send_key: "C-a"
+      - send_key: "S-Right"
+      - send_key: "S-Right"
+      - send_key: "Left"
+      - send: "X"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "Xabcd"
+    match_type: "contains"
+
+  - name: "Shift+Right then Shift+Left auto-collapses at anchor"
+    # Anchor=0, cursor 0→1→0. update_selection_on_shift_motion
+    # auto-collapses when cursor returns to anchor. Next plain Right
+    # moves normally (one char), not snap.
+    steps:
+      - send: "abcd"
+      - send_key: "C-a"
+      - send_key: "S-Right"
+      - send_key: "S-Left"
+      - send_key: "Right"
+      - send: "X"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "aXbcd"
+    match_type: "contains"
+
+  # =============================================================
+  # SHIFT+HOME / SHIFT+END: line-edge extension
+  # =============================================================
+
+  - name: "Shift+End selects to end; plain Left snaps to left edge"
+    # Type abcd, C-a (cursor=0), Shift+End (anchor=0, cursor=4), plain
+    # Left snaps to 0, insert X at 0 → "Xabcd".
+    steps:
+      - send: "abcd"
+      - send_key: "C-a"
+      - send_key: "S-End"
+      - send_key: "Left"
+      - send: "X"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "Xabcd"
+    match_type: "contains"
+
+  - name: "Shift+Home selects to start; plain Right snaps to right edge"
+    # Type abcd (cursor=4), Shift+Home (anchor=4, cursor=0), plain Right
+    # snaps to max(4,0)=4, insert X at 4 → "abcdX".
+    steps:
+      - send: "abcd"
+      - send_key: "S-Home"
+      - send_key: "Right"
+      - send: "X"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "abcdX"
+    match_type: "contains"
+
+  # =============================================================
+  # CTRL+SHIFT+LEFT / CTRL+SHIFT+RIGHT: word-wise extension
+  # =============================================================
+
+  - name: "Ctrl+Shift+Left word-wise selection snaps to word start"
+    # "aaa bbb" (cursor=7). C-S-Left → move_to_previous_word lands
+    # cursor at 4 (before 'b' of "bbb"), anchor=7. Plain Left snaps
+    # to min(7,4)=4. X at 4 → "aaa Xbbb".
+    steps:
+      - send: "aaa bbb"
+      - send_key: "C-S-Left"
+      - send_key: "Left"
+      - send: "X"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "aaa Xbbb"
+    match_type: "contains"
+
+  - name: "Ctrl+Shift+Right word-wise selection snaps to word end"
+    # "aaa bbb ccc" (cursor=11). C-a (cursor=0). C-S-Right →
+    # move_to_next_word lands at 3 (end of "aaa"), anchor=0. Plain Right
+    # snaps to max(0,3)=3. X at 3 → "aaaX bbb ccc".
+    steps:
+      - send: "aaa bbb ccc"
+      - send_key: "C-a"
+      - send_key: "C-S-Right"
+      - send_key: "Right"
+      - send: "X"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "aaaX bbb ccc"
+    match_type: "contains"
+
+  # =============================================================
+  # ALT+SHIFT+B / ALT+SHIFT+F: emacs-native word-wise selection
+  # (ESC-uppercase is xterm's Alt+Shift+letter encoding.)
+  # =============================================================
+
+  - name: "Alt+Shift+B (ESC uppercase B) extends selection one word back"
+    steps:
+      - send: "aaa bbb"
+      - send_key: "M-B"
+      - send_key: "Left"
+      - send: "X"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "aaa Xbbb"
+    match_type: "contains"
+
+  - name: "Alt+Shift+F (ESC uppercase F) extends selection one word forward"
+    steps:
+      - send: "aaa bbb ccc"
+      - send_key: "C-a"
+      - send_key: "M-F"
+      - send_key: "Right"
+      - send: "X"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "aaaX bbb ccc"
+    match_type: "contains"
+
+  # =============================================================
+  # REGRESSION GUARDS: plain motion with no selection still works
+  # =============================================================
+
+  - name: "Plain Left with no selection still moves one char"
+    steps:
+      - send: "abcd"
+      - send_key: "Left"
+      - send: "X"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "abcXd"
+    match_type: "contains"
+
+  - name: "Plain Right with no selection still moves one char"
+    steps:
+      - send: "abcd"
+      - send_key: "C-a"
+      - send_key: "Right"
+      - send: "X"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "aXbcd"
+    match_type: "contains"
+
+  - name: "Plain Alt+b word-back with no selection still moves one word"
+    # Baseline check: Alt+b (lowercase) still jumps to word start and
+    # does NOT engage selection mode.
+    steps:
+      - send: "aaa bbb"
+      - send_key: "M-b"
+      - send: "X"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "aaa Xbbb"
+    match_type: "contains"
+
+  - name: "Plain Alt+f word-forward with no selection still moves one word"
+    steps:
+      - send: "aaa bbb ccc"
+      - send_key: "C-a"
+      - send_key: "M-f"
+      - send: "X"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "aaaX bbb ccc"
+    match_type: "contains"
+
+  # =============================================================
+  # HISTORY NAVIGATION CLEARS SELECTION (#27)
+  # After Up/Down round-trip, selection must be gone — subsequent
+  # plain motion should NOT snap to an orphan anchor.
+  # =============================================================
+
+  - name: "History Up clears active selection (#27)"
+    # Type "abcd", S-Left x2 → anchor=4, cursor=2, active.
+    # Up enters prefix-search mode. No history entry matches "abcd",
+    # so buffer/cursor stay put — but selection must still be cleared
+    # per #27. Subsequent plain Right then has NO anchor to snap to,
+    # so it moves one char normally: cursor 2 → 3. X at 3 → "abcXd".
+    #
+    # Without #27: collapse_selection is skipped in handle_history_up,
+    # selection stays active (anchor=4, cursor=2). Next plain Right
+    # snaps to max(4,2)=4, X at 4 → "abcdX". Test would fail.
+    steps:
+      - send_line: "echo first"
+      - send: "abcd"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "Up"
+      - send_key: "Right"
+      - send: "X"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "abcXd"
+    match_type: "contains"
+
+  # =============================================================
+  # REGRESSION GUARD: modifier 4 (Alt+Shift+Arrow) still navigates
+  # directories, not selection — ensure we didn't steal its encoding.
+  # =============================================================
+
+  - name: "Alt+Shift+Up still triggers cd .. (dir nav binding intact)"
+    # Send pwd, then Alt+Shift+Up which fortsh binds to 'cd ..' and
+    # auto-executes, then pwd again. Second pwd should be parent of first.
+    steps:
+      - send_line: "pwd"
+      - send_key: "M-S-Up"
+      - send_line: "pwd"
+    expect_output: "/"
+    match_type: "contains"

--- a/tests/interactive/test_specs/selection.yaml
+++ b/tests/interactive/test_specs/selection.yaml
@@ -540,3 +540,63 @@ tests:
       - send_key: "Enter"
     expect_output: "hello"
     match_type: "contains"
+
+  # =============================================================
+  # SPRINT 6 — BRACKETED PASTE MODE
+  # The enable (ESC[?2004h) and payload parser (ESC[200~...ESC[201~)
+  # predate the shift phase. Sprint 6 adds the FORTSH_NO_BRACKETED_PASTE
+  # kill switch and verifies the Sprint 3 insert_char_wrapper hook
+  # makes bracketed paste replace an active selection.
+  # =============================================================
+
+  - name: "Sprint 6: bracketed paste inserts at cursor"
+    # Baseline: send a bracketed paste payload. The terminal would send
+    # ESC[200~<text>ESC[201~ when a user pastes. Our parser consumes
+    # the framing and inserts the inner text.
+    steps:
+      - send: "echo "
+      - send: "\u001b[200~pasted_text\u001b[201~"
+      - send_key: "Enter"
+    expect_output: "pasted_text"
+    match_type: "contains"
+
+  - name: "Sprint 6: bracketed paste replaces active selection"
+    # Type "echo hello world", select "world" via Shift+Left x5, then
+    # fire a bracketed paste. The first char of the paste triggers
+    # delete_selection (Sprint 3 insert_char_wrapper hook); subsequent
+    # chars insert normally. Buffer becomes "echo hello BRACKET".
+    steps:
+      - send: "echo hello world"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send: "\u001b[200~BRACKET\u001b[201~"
+      - send_key: "Enter"
+    expect_output: "hello BRACKET"
+    match_type: "contains"
+
+  - name: "Sprint 6: bracketed paste without selection just inserts"
+    # Regression guard: with no active selection, bracketed paste inserts
+    # at cursor without any deletion. Type "aa", paste "BB", Enter → "aaBB".
+    steps:
+      - send: "echo aa"
+      - send: "\u001b[200~BB\u001b[201~"
+      - send_key: "Enter"
+    expect_output: "aaBB"
+    match_type: "contains"
+
+  - name: "Sprint 6: FORTSH_NO_BRACKETED_PASTE kill switch does not crash"
+    # When the kill switch is set, fortsh does NOT emit the enable
+    # sequence (verified manually via pexpect — PTY regex can't easily
+    # assert absence of ESC[?2004h in output). This test just ensures
+    # fortsh still functions with the kill switch set: prompt returns,
+    # echo executes, no crash on startup/teardown.
+    env:
+      FORTSH_NO_BRACKETED_PASTE: "1"
+    fresh_session: true
+    steps:
+      - send_line: "echo hi"
+    expect_output: "hi"
+    match_type: "contains"

--- a/tests/interactive/test_specs/selection.yaml
+++ b/tests/interactive/test_specs/selection.yaml
@@ -600,3 +600,314 @@ tests:
       - send_line: "echo hi"
     expect_output: "hi"
     match_type: "contains"
+
+  # =============================================================
+  # SPRINT 7 — EXPANDED COVERAGE
+  # UTF-8 safety, explicit collapse-on-motion for every movement
+  # type, Shift+Up/Down, and edge cases across all categories.
+  # =============================================================
+
+  # ---------- UTF-8 safety (pattern #11) ----------
+
+  - name: "Sprint 7 UTF-8: Shift+Left over emoji selects one full codepoint"
+    # Emoji 🎉 is U+1F389, encoded as 4 UTF-8 bytes (F0 9F 8E 89).
+    # Shift+Left from end of "ab🎉" should move cursor back 4 bytes,
+    # selecting just the emoji (not half of it). Type 'Z' → "abZ".
+    # If byte-safe stepping broke, we'd corrupt the codepoint.
+    steps:
+      - send: "ab🎉"
+      - send_key: "S-Left"
+      - send: "Z"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "abZ"
+    match_type: "contains"
+
+  - name: "Sprint 7 UTF-8: Backspace over selected emoji removes 4 bytes"
+    steps:
+      - send: "ab🎉cd"
+      - send_key: "Left"
+      - send_key: "Left"
+      - send_key: "S-Left"
+      - send_key: "Backspace"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "abcd"
+    match_type: "contains"
+
+  - name: "Sprint 7 UTF-8: Ctrl+W cuts selection containing multi-byte chars"
+    # Accented 'é' is 2 bytes (C3 A9). Select "éé" with Shift+Left x2,
+    # cut with Ctrl+W. Buffer left with "ab".
+    steps:
+      - send: "abéé"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "C-w"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "ab"
+    match_type: "contains"
+
+  - name: "Sprint 7 UTF-8: type-over multi-byte selection inserts ASCII cleanly"
+    steps:
+      - send: "héllo"
+      - send_key: "S-Home"
+      - send: "X"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "X"
+    match_type: "contains"
+
+  # ---------- Collapse-on-motion for every movement type ----------
+
+  - name: "Sprint 7 collapse: plain Home with selection clears, goes to 0"
+    steps:
+      - send: "abcd"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "Home"
+      - send: "Z"
+      - send_key: "C-e"
+      - send: " x"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    # Selection=[2..4). Plain Home clears, cursor=0. Z at 0 → "Zabcd x".
+    expect_output: "Zabcd x"
+    match_type: "contains"
+
+  - name: "Sprint 7 collapse: plain End with selection clears, goes to length"
+    steps:
+      - send: "abcd"
+      - send_key: "C-a"
+      - send_key: "S-Right"
+      - send_key: "S-Right"
+      - send_key: "End"
+      - send: "Z"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    # Selection=[0..2). Plain End clears, cursor=4. Z at 4 → "abcdZ".
+    expect_output: "abcdZ"
+    match_type: "contains"
+
+  - name: "Sprint 7 collapse: plain Alt+f with selection clears, moves word fwd"
+    steps:
+      - send: "aaa bbb ccc"
+      - send_key: "C-a"
+      - send_key: "S-Right"  # cursor=1, anchor=0
+      - send_key: "M-f"      # clears selection, moves to end of "aaa" = 3
+      - send: "Z"            # insert at 3 → "aaaZ bbb ccc"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "aaaZ bbb ccc"
+    match_type: "contains"
+
+  - name: "Sprint 7 collapse: plain Alt+b with selection clears, moves word back"
+    steps:
+      - send: "aaa bbb"
+      - send_key: "S-Left"   # cursor=6, anchor=7
+      - send_key: "M-b"      # clears, moves to start of word ("bbb" at 4)
+      - send: "Z"            # insert at 4 → "aaa Zbbb"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "aaa Zbbb"
+    match_type: "contains"
+
+  # ---------- Shift+Up / Shift+Down (line-wise on single-line prompt) ----------
+
+  - name: "Sprint 7 line-wise: Shift+Up extends selection to line start"
+    # Single-line prompt: Shift+Up = Shift+Home. Type "abcd", Shift+Up
+    # anchors at 4, moves cursor to 0. Type 'Z' → buffer "Z" (selection
+    # replaced by 'Z').
+    steps:
+      - send: "abcd"
+      - send_key: "S-Up"
+      - send: "Z"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "Z"
+    match_type: "contains"
+
+  - name: "Sprint 7 line-wise: Shift+Down extends selection to line end"
+    # Shift+Down = Shift+End on single-line prompt.
+    steps:
+      - send: "abcd"
+      - send_key: "C-a"
+      - send_key: "S-Down"
+      - send: "Z"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "Z"
+    match_type: "contains"
+
+  # ---------- Word-wise extension variations ----------
+
+  - name: "Sprint 7 word: Ctrl+Shift+Left twice extends over two words"
+    # "aaa bbb ccc" (cursor=11). C-S-Left → cursor=8, anchor=11. Again →
+    # cursor=4, anchor=11. Selection spans "bbb ccc" [4..11). Backspace
+    # deletes → "aaa ". Echo → "aaa".
+    steps:
+      - send: "aaa bbb ccc"
+      - send_key: "C-S-Left"
+      - send_key: "C-S-Left"
+      - send_key: "Backspace"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "aaa"
+    match_type: "contains"
+
+  - name: "Sprint 7 word: Alt+Shift+F twice extends over two words"
+    # "aaa bbb ccc", C-a. M-F → cursor=3 (end of aaa). M-F → cursor=7
+    # (end of bbb). anchor=0, cursor=7. Selection="aaa bbb". Backspace
+    # → " ccc". Leading space gets stripped by shell word-split.
+    steps:
+      - send: "aaa bbb ccc"
+      - send_key: "C-a"
+      - send_key: "M-F"
+      - send_key: "M-F"
+      - send_key: "Backspace"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "ccc"
+    match_type: "contains"
+
+  - name: "Sprint 7 word: Ctrl+Shift+Right from mid-word jumps to word end"
+    # "aaa bbb" (cursor=7). C-a (cursor=0). Right (cursor=1, mid-"aaa").
+    # C-S-Right → move_to_next_word from 1 lands at end of "aaa" = 3.
+    # anchor=1, cursor=3. Plain Right snaps to max(1,3)=3.
+    # Insert Z at 3 → "aaaZ bbb".
+    steps:
+      - send: "aaa bbb"
+      - send_key: "C-a"
+      - send_key: "Right"
+      - send_key: "C-S-Right"
+      - send_key: "Right"
+      - send: "Z"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "aaaZ bbb"
+    match_type: "contains"
+
+  # ---------- Cut / copy / paste edge cases ----------
+
+  - name: "Sprint 7 edge: cut then paste at different position"
+    # Type "aaa bbb", select "bbb" (C-S-Left), Ctrl+W cuts, Ctrl+A to
+    # start, Ctrl+Y pastes → "bbbaaa ". (Note: no space between bbb
+    # and aaa since the original space was in "aaa bbb" not moved.)
+    steps:
+      - send: "aaa bbb"
+      - send_key: "C-S-Left"
+      - send_key: "C-w"
+      - send_key: "C-a"
+      - send_key: "C-y"
+      - send_key: "C-e"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    # Buffer trace: C-S-Left from 7 → 4, anchor=7, sel="bbb".
+    # Ctrl+W → buffer "aaa ", cursor=4, kill_buffer="bbb".
+    # C-a → cursor=0. C-y pastes "bbb" at 0 → "bbbaaa ", cursor=3.
+    # C-e → cursor=7. C-a → cursor=0. echo + Enter → "bbbaaa".
+    expect_output: "bbbaaa"
+    match_type: "contains"
+
+  - name: "Sprint 7 edge: Ctrl+Y at start of empty buffer pastes"
+    steps:
+      - send: "saved"
+      - send_key: "C-u"        # kills all into kill buffer
+      - send_key: "C-y"        # yanks back
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "saved"
+    match_type: "contains"
+
+  - name: "Sprint 7 edge: Ctrl+Y without kill buffer no-ops"
+    # If kill_length == 0, Ctrl+Y returns without change. The buffer
+    # here only has "hi", and Ctrl+Y should not corrupt it.
+    steps:
+      - send: "hi"
+      - send_key: "C-y"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "hi"
+    match_type: "contains"
+
+  # ---------- Backspace / Delete edge cases ----------
+
+  - name: "Sprint 7 edge: Backspace with selection at buffer start works"
+    # Select "ab" from start, Backspace removes it → "cd".
+    steps:
+      - send: "abcd"
+      - send_key: "C-a"
+      - send_key: "S-Right"
+      - send_key: "S-Right"
+      - send_key: "Backspace"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "cd"
+    match_type: "contains"
+
+  - name: "Sprint 7 edge: Delete with selection at buffer end works"
+    # Select "cd" from end, Delete removes → "ab".
+    steps:
+      - send: "abcd"
+      - send_key: "S-Left"
+      - send_key: "S-Left"
+      - send_key: "Delete"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "ab"
+    match_type: "contains"
+
+  # ---------- Alt+W copy additional coverage ----------
+
+  - name: "Sprint 7 copy: Alt+W then immediately Ctrl+Y pastes duplicate"
+    # Alt+W leaves selection un-deleted but collapses it. Ctrl+Y then
+    # yanks the copied text at cursor → text is duplicated.
+    steps:
+      - send: "abcd"
+      - send_key: "S-Home"     # select "abcd", cursor=0, anchor=4
+      - send_key: "M-w"        # copy + collapse (cursor stays at 0? or 4?)
+      - send_key: "C-e"        # move to end (should be 4)
+      - send_key: "C-y"        # paste "abcd" → "abcdabcd"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "abcdabcd"
+    match_type: "contains"
+
+  # ---------- Abort selection paths ----------
+
+  - name: "Sprint 7 abort: Ctrl+G / Escape does not carry selection through"
+    # Ctrl+G cancels search mode but doesn't directly touch selection.
+    # However, after clearing, normal editing should show no snap.
+    # Verify: select text, send a word motion WITHOUT shift — selection
+    # clears and cursor moves. Then Backspace deletes ONE char (not
+    # whole selection).
+    steps:
+      - send: "abcdef"
+      - send_key: "S-Left"
+      - send_key: "S-Left"     # anchor=6, cursor=4
+      - send_key: "Left"       # collapse to left edge (4), no motion
+      - send_key: "Backspace"  # delete ONE char (not selection) at 4 → "abcef"
+      - send_key: "C-a"
+      - send: "echo "
+      - send_key: "Enter"
+    expect_output: "abcef"
+    match_type: "contains"

--- a/tests/interactive/utils/keys.py
+++ b/tests/interactive/utils/keys.py
@@ -69,6 +69,7 @@ ALT_F = "\x1bf"  # Forward one word
 ALT_L = "\x1bl"  # Lowercase word
 ALT_T = "\x1bt"  # Transpose words
 ALT_U = "\x1bu"  # Uppercase word
+ALT_W = "\x1bw"  # Copy selection (shift phase) / Accept word from suggestion
 ALT_Y = "\x1by"  # Yank pop
 ALT_DOT = "\x1b."  # Insert last argument
 ALT_BACKSPACE = "\x1b\x7f"  # Delete word backward
@@ -165,6 +166,7 @@ KEYS = {
     "M-l": ALT_L,
     "M-t": ALT_T,
     "M-u": ALT_U,
+    "M-w": ALT_W,
     "M-y": ALT_Y,
     "M-.": ALT_DOT,
     "M-Backspace": ALT_BACKSPACE,

--- a/tests/interactive/utils/keys.py
+++ b/tests/interactive/utils/keys.py
@@ -10,6 +10,29 @@ ARROW_DOWN = "\x1b[B"
 ARROW_RIGHT = "\x1b[C"
 ARROW_LEFT = "\x1b[D"
 
+# Shift-modified arrow / nav keys (xterm modifier 2 = Shift)
+# Used for native text selection (shift phase, Sprint 1+).
+SHIFT_ARROW_UP = "\x1b[1;2A"
+SHIFT_ARROW_DOWN = "\x1b[1;2B"
+SHIFT_ARROW_RIGHT = "\x1b[1;2C"
+SHIFT_ARROW_LEFT = "\x1b[1;2D"
+SHIFT_HOME = "\x1b[1;2H"
+SHIFT_END = "\x1b[1;2F"
+
+# Ctrl+Shift arrow (xterm modifier 6) — word-wise selection extension
+CTRL_SHIFT_ARROW_RIGHT = "\x1b[1;6C"
+CTRL_SHIFT_ARROW_LEFT = "\x1b[1;6D"
+
+# Alt+Shift letter (ESC + uppercase) — emacs-native word-wise selection
+ALT_SHIFT_B = "\x1bB"
+ALT_SHIFT_F = "\x1bF"
+
+# Alt+Shift arrow (xterm modifier 4) — fortsh binds these to dir history
+ALT_SHIFT_UP = "\x1b[1;4A"
+ALT_SHIFT_DOWN = "\x1b[1;4B"
+ALT_SHIFT_LEFT = "\x1b[1;4D"
+ALT_SHIFT_RIGHT = "\x1b[1;4C"
+
 # Control keys (ASCII control characters)
 CTRL_A = "\x01"  # Beginning of line
 CTRL_B = "\x02"  # Back one character
@@ -90,6 +113,28 @@ KEYS = {
     "Down": ARROW_DOWN,
     "Right": ARROW_RIGHT,
     "Left": ARROW_LEFT,
+
+    # Shift-modified navigation (for native text selection)
+    "S-Up": SHIFT_ARROW_UP,
+    "S-Down": SHIFT_ARROW_DOWN,
+    "S-Right": SHIFT_ARROW_RIGHT,
+    "S-Left": SHIFT_ARROW_LEFT,
+    "S-Home": SHIFT_HOME,
+    "S-End": SHIFT_END,
+
+    # Ctrl+Shift navigation (word-wise selection)
+    "C-S-Right": CTRL_SHIFT_ARROW_RIGHT,
+    "C-S-Left": CTRL_SHIFT_ARROW_LEFT,
+
+    # Alt+Shift letter (emacs word-wise selection)
+    "M-B": ALT_SHIFT_B,
+    "M-F": ALT_SHIFT_F,
+
+    # Alt+Shift arrows (fortsh directory history, NOT selection)
+    "M-S-Up": ALT_SHIFT_UP,
+    "M-S-Down": ALT_SHIFT_DOWN,
+    "M-S-Left": ALT_SHIFT_LEFT,
+    "M-S-Right": ALT_SHIFT_RIGHT,
 
     # Control keys
     "C-a": CTRL_A,

--- a/tests/interactive/utils/keys.py
+++ b/tests/interactive/utils/keys.py
@@ -55,7 +55,7 @@ CTRL_R = "\x12"  # Reverse search
 CTRL_S = "\x13"  # Forward search / Suspend output
 CTRL_T = "\x14"  # Transpose characters
 CTRL_U = "\x15"  # Kill to beginning of line
-CTRL_V = "\x16"  # Quoted insert
+CTRL_V = "\x16"  # Paste from clipboard / kill buffer
 CTRL_W = "\x17"  # Kill word backward
 CTRL_X = "\x18"  # Prefix
 CTRL_Y = "\x19"  # Yank
@@ -154,6 +154,7 @@ KEYS = {
     "C-s": CTRL_S,
     "C-t": CTRL_T,
     "C-u": CTRL_U,
+    "C-v": CTRL_V,
     "C-w": CTRL_W,
     "C-y": CTRL_Y,
     "C-z": CTRL_Z,

--- a/tests/interactive/utils/keys.py
+++ b/tests/interactive/utils/keys.py
@@ -56,8 +56,8 @@ CTRL_S = "\x13"  # Forward search / Suspend output
 CTRL_T = "\x14"  # Transpose characters
 CTRL_U = "\x15"  # Kill to beginning of line
 CTRL_V = "\x16"  # Paste from clipboard / kill buffer
-CTRL_W = "\x17"  # Kill word backward
-CTRL_X = "\x18"  # Prefix
+CTRL_W = "\x17"  # Kill word backward / cut selection
+CTRL_X = "\x18"  # Cut selection / process kill mode
 CTRL_Y = "\x19"  # Yank
 CTRL_Z = "\x1a"  # Suspend (SIGTSTP)
 
@@ -156,6 +156,7 @@ KEYS = {
     "C-u": CTRL_U,
     "C-v": CTRL_V,
     "C-w": CTRL_W,
+    "C-x": CTRL_X,
     "C-y": CTRL_Y,
     "C-z": CTRL_Z,
 


### PR DESCRIPTION
## Overview

fortsh 1.7.0 adds **native shift-arrow text selection** to the emacs-mode line editor, with three-segment reverse-video rendering and a system-clipboard bridge that auto-detects `pbcopy` / `wl-copy` / `xclip` / `xsel` at startup. Behavior matches modern GUI editors: select with Shift+motion, type-over replaces, plain motion collapses, Ctrl+W/X cuts, Alt+W copies, Ctrl+V pastes from the system clipboard with kill-buffer fallback.

## What's new

**Text selection (emacs mode):**
- `Shift+Left/Right` — char-wise extension
- `Shift+Home/End` — line-edge extension
- `Shift+Up/Down` — line-wise (= Home/End on single-line prompt)
- `Ctrl+Shift+Left/Right` — word-wise extension
- `Alt+Shift+B/F` — emacs-native word-wise alternative
- Plain motion collapses; char-motions snap to the selection edge
- Live `ESC[7m` reverse-video rendering, terminal-agnostic (works on Terminal.app, iTerm2, Ghostty, gnome-terminal)

**Editing on the selection:**
- Typing a printable char, Backspace, or Delete replaces the selection
- `Ctrl+W` / `Ctrl+X` — cut (Ctrl+X is dual-mode: falls back to process-kill-mode when no selection)
- `Alt+W` — copy without delete
- `Ctrl+Y` — paste from kill buffer (deletes selection first if active)
- `Ctrl+V` — paste from system clipboard; falls back to kill buffer if no tool

**System clipboard bridge:**
- Probes pbcopy / wl-copy / xclip / xsel once at readline init
- Cut and copy mirror to system clipboard via `popen("w") + fputs`
- Paste reads via `popen("r") + fgets`
- Graceful no-op if no tool found — kill buffer remains source of truth

**Bracketed paste mode:**
- `ESC[?2004h` enable predates this release; new `FORTSH_NO_BRACKETED_PASTE=1` kill switch
- Bracketed paste over an active selection replaces the selection (composes through the type-over hook in \`insert_char_wrapper\`)

**Bug fix:** Plain `Home` and `End` keys (VT100 `ESC[H` / `ESC[F` encoding) now work; previously only the tilde variants `ESC[1~` / `ESC[4~` were handled.

## Test coverage

55-test PTY suite at \`tests/interactive/test_specs/selection.yaml\` covering:

- UTF-8 boundary safety (emoji 4-byte codepoints, accented 2-byte chars)
- Every collapse-on-motion path (Home, End, Alt+b, Alt+f, plain arrows)
- Snap-to-edge behavior for char motion
- All cut/copy/paste round-trips
- Bracketed paste replacement of active selection
- Visible reverse-video rendering checks (ESC[7m...ESC[27m presence)
- Modifier-4 (Alt+Shift+Arrow) directory-nav regression guard
- History-up clears selection regression guard

## Env flags

- `FORTSH_DEBUG_SELECTION=1` — stderr trace on every selection state change
- `FORTSH_NO_BRACKETED_PASTE=1` — disable `ESC[?2004h` emit (terminal-compat triage)

## Architecture notes

- Selection state (`selection_anchor` int + `selection_active` logical) is appended to the **end** of \`input_state_t\` — the stack layout has been tuned around macOS ARM64 Red Zone constraints, so do not reorder.
- Module-level `module_extending_selection` flag is toggled by the shift-dispatch in \`handle_extended_escape_sequence\` immediately before/after calling base motion handlers. Avoids passing the 200+ byte derived type across new function boundaries (flang-new ABI workaround).
- Three-segment render lives inline in the existing redraw block at \`readline.f90:~1431\` — not factored into a subroutine, again to avoid passing \`input_state_t\` across a call.
- Reverse video chosen over ANSI background colors — proven across all tested terminals; macOS Terminal.app handles 256-color backgrounds inconsistently.

## Known limitations

On macOS ARM64 builds without `USE_C_STRINGS`, the live editing buffer (and thus the maximum selectable range within one command) is capped at 127 chars. Default builds enable C strings and lift this to 1024. System clipboard payload itself is unlimited; pasting into readline truncates to fit.

## Test plan

- [x] CI green on x86_64 Linux (gfortran)
- [x] CI green on ARM64 Linux (gfortran)
- [x] CI green on macOS ARM64 (flang-new)
- [x] Manual smoke: shift-select on macOS Terminal.app, iTerm2 (verified locally)
- [x] `pbpaste` round-trip after Alt+W on macOS (verified locally)
- [x] Graceful fallback when no clipboard tool available (verified by env override)