### PR TITLE
bump PKGBUILD and .SRCINFO to 1.7.0

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,14 +1,15 @@
 pkgbase = fortsh
 	pkgdesc = Fortran Shell - A modern shell implementation with AST-based parsing
-	pkgver = 0.8.0
+	pkgver = 1.7.0
 	pkgrel = 1
 	url = https://github.com/FortranGoingOnForty/fortsh
 	arch = x86_64
-	license = MIT
+	arch = aarch64
+	license = GPL-3.0-only
 	makedepends = gcc-fortran
 	makedepends = make
 	depends = glibc
-	source = git+https://github.com/FortranGoingOnForty/fortsh.git#tag=v0.8.0
+	source = git+https://github.com/FortranGoingOnForty/fortsh.git#tag=v1.7.0
 	sha256sums = SKIP
 
 pkgname = fortsh

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: mfw <espadonne@outlook.com>
 
 pkgname=fortsh
-pkgver=1.5.0
+pkgver=1.7.0
 pkgrel=1
 pkgdesc='Fortran Shell - A modern shell implementation with AST-based parsing'
 arch=('x86_64' 'aarch64')


### PR DESCRIPTION
Keeps the in-repo AUR metadata in sync with the v1.7.0 release tag. No source changes — just the packaging files.