### PR TITLE
Native directory enumeration (opendir/readdir) — fix prompt-duplication bug, remove ls/grep shell-outs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ else ifeq ($(UNAME_S),Darwin)
 endif
 
 # Core C objects needed on all platforms (fd operations, terminal size, string ops)
-CORE_C_OBJS = $(BUILDDIR)/c_interop/fd_wrapper.o $(BUILDDIR)/c_interop/terminal_size.o $(BUILDDIR)/c_interop/fortsh_strings.o
+CORE_C_OBJS = $(BUILDDIR)/c_interop/fd_wrapper.o $(BUILDDIR)/c_interop/terminal_size.o $(BUILDDIR)/c_interop/fortsh_strings.o $(BUILDDIR)/c_interop/fortsh_dir.o
 
 ifeq ($(USE_C_STRINGS),1)
   C_STRING_LIB = $(BUILDDIR)/c_interop/libfortsh_strings.a
@@ -367,6 +367,10 @@ $(BUILDDIR)/c_interop/fd_wrapper.o: src/c_interop/fd_wrapper.c | $(BUILDDIR)/c_i
 
 # Compile C terminal size wrapper
 $(BUILDDIR)/c_interop/terminal_size.o: src/c_interop/terminal_size.c | $(BUILDDIR)/c_interop
+	$(CC) $(CFLAGS) -c $< -o $@
+
+# Compile native directory enumeration helper (replaces shelling out to ls)
+$(BUILDDIR)/c_interop/fortsh_dir.o: src/c_interop/fortsh_dir.c | $(BUILDDIR)/c_interop
 	$(CC) $(CFLAGS) -c $< -o $@
 
 # Create static library from C objects

--- a/src/c_interop/fortsh_dir.c
+++ b/src/c_interop/fortsh_dir.c
@@ -1,0 +1,59 @@
+// Native directory enumeration for fortsh.
+//
+// Replaces shelling out to `ls` (and `ls | grep`) for completion and glob.
+// A name-based API keeps the platform-specific `struct dirent` layout entirely
+// on the C side — Fortran never needs to know it, exactly like fd_wrapper.c
+// hides `struct stat`. Works on Linux, macOS, and FreeBSD.
+
+#include <dirent.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <string.h>
+
+// Open a directory. Returns an opaque DIR* (as void*), or NULL on failure.
+void *fortsh_opendir(const char *path) {
+    return (void *)opendir(path);
+}
+
+// Read the next entry from an open directory.
+//   name_buf / buf_len : caller buffer; the entry name is copied NUL-terminated
+//                        (truncated if it would not fit).
+//   is_dir             : set to 1 if the entry is a directory (symlinks to
+//                        directories are followed), else 0.
+// Returns 1 when an entry was produced, 0 at end of directory / on error.
+int fortsh_readdir(void *dirp, char *name_buf, int buf_len, int *is_dir) {
+    DIR *d = (DIR *)dirp;
+    struct dirent *e;
+
+    if (d == NULL || name_buf == NULL || buf_len <= 0) return 0;
+
+    e = readdir(d);
+    if (e == NULL) return 0;
+
+    strncpy(name_buf, e->d_name, (size_t)(buf_len - 1));
+    name_buf[buf_len - 1] = '\0';
+
+    // Determine directory-ness. d_type is fast but not universally populated
+    // (some filesystems report DT_UNKNOWN), and symlinks report DT_LNK — for
+    // completion we want to follow links, so stat those via fstatat (relative
+    // to the open dir fd, so no path reconstruction is needed).
+    *is_dir = 0;
+#ifdef DT_DIR
+    if (e->d_type == DT_DIR) {
+        *is_dir = 1;
+    } else if (e->d_type == DT_LNK || e->d_type == DT_UNKNOWN) {
+#endif
+        struct stat st;
+        if (fstatat(dirfd(d), e->d_name, &st, 0) == 0 && S_ISDIR(st.st_mode)) {
+            *is_dir = 1;
+        }
+#ifdef DT_DIR
+    }
+#endif
+
+    return 1;
+}
+
+void fortsh_closedir(void *dirp) {
+    if (dirp != NULL) closedir((DIR *)dirp);
+}

--- a/src/io/readline.f90
+++ b/src/io/readline.f90
@@ -3596,11 +3596,10 @@ contains
     character(len=MAX_LINE_LEN), intent(out) :: completions(MAX_LOCAL_COMPLETIONS)
     integer, intent(out) :: num_completions
 
+    integer, parameter :: MAX_DIR_ENTRIES = 4096
     character(len=MAX_LINE_LEN) :: dir_path, file_pattern
-    character(len=1024) :: ls_command
-    character(len=:), allocatable :: ls_output_alloc
-    character(len=8192) :: ls_output  ! Large buffer for ls output (8KB)
-    character(len=MAX_LINE_LEN), allocatable :: entries(:)  ! Now allocatable to avoid stack overflow
+    character(len=256), allocatable :: entries(:)
+    logical, allocatable :: is_dir_flags(:)
     integer :: num_entries, i, last_slash_pos
     character(len=MAX_LINE_LEN) :: full_path
     logical :: is_dir
@@ -3625,19 +3624,9 @@ contains
       file_pattern = trim(pattern)
     end if
 
-    ! Use ls command to get directory listing (same as scan_directory)
-    ls_command = 'ls -1a "' // trim(dir_path) // '" 2>/dev/null'
-    ls_output_alloc = execute_and_capture(ls_command)
-
-    ! Copy to fixed buffer (use larger buffer to avoid truncation)
-    if (allocated(ls_output_alloc)) then
-      ls_output = ls_output_alloc(:min(len(ls_output), len(ls_output_alloc)))
-    else
-      ls_output = ''
-    end if
-
-    ! Parse ls output into individual entries
-    call parse_ls_output(ls_output, entries, num_entries)
+    ! Enumerate the directory natively (opendir/readdir) — same as scan_directory
+    allocate(entries(MAX_DIR_ENTRIES), is_dir_flags(MAX_DIR_ENTRIES))
+    call list_directory(trim(dir_path), entries, is_dir_flags, num_entries)
 
     ! Match entries against glob pattern
     do i = 1, num_entries
@@ -3655,8 +3644,8 @@ contains
           full_path = trim(dir_path) // '/' // trim(entries(i))
         end if
 
-        ! Check if it's a directory and add trailing slash
-        is_dir = is_directory(full_path)
+        ! Directory-ness comes straight from readdir (no per-entry test -d)
+        is_dir = is_dir_flags(i)
         num_completions = num_completions + 1
         if (is_dir) then
           completions(num_completions) = trim(full_path) // '/'
@@ -3666,8 +3655,9 @@ contains
       end if
     end do
 
-    ! Clean up allocatable array
+    ! Clean up allocatable arrays
     if (allocated(entries)) deallocate(entries)
+    if (allocated(is_dir_flags)) deallocate(is_dir_flags)
   end subroutine expand_glob_for_completion
 
   subroutine complete_commands(prefix, completions, num_completions)
@@ -3947,10 +3937,10 @@ contains
     character(len=MAX_LINE_LEN), intent(inout) :: completions(MAX_LOCAL_COMPLETIONS)
     integer, intent(inout) :: num_completions
 
-    character(len=1024) :: ls_command, expanded_dir  ! Large enough for command
-    character(len=:), allocatable :: ls_output_alloc  ! From execute_and_capture
-    character(len=8192) :: ls_output  ! 8KB buffer for large directories (with grep filter)
-    character(len=MAX_LINE_LEN), allocatable :: entries(:)  ! Now allocatable to avoid stack overflow
+    integer, parameter :: MAX_DIR_ENTRIES = 4096
+    character(len=1024) :: expanded_dir
+    character(len=256), allocatable :: entries(:)       ! one filename per slot
+    logical, allocatable :: is_dir_flags(:)             ! parallel to entries
     character(len=MAX_LINE_LEN) :: full_path
     character(len=:), allocatable :: home_dir, debug_mode
     ! Use allocatable array to avoid static storage
@@ -3985,72 +3975,32 @@ contains
       end if
     end if
 
-    ! Use ls command with -F flag to mark directories with / (avoids calling test -d for each file)
-    ! Trailing / on directory forces ls to list contents (not the symlink itself on macOS)
-    ! When pattern is non-empty, filter with grep to avoid buffer overflow on large directories
-    ! Use tr to convert newlines to spaces for easier parsing
-    ! Filter with grep when pattern exists to limit output size
-    ! No tr needed — execute_and_capture_tabs converts newlines to tabs
-    if (pattern_len > 0) then
-      ls_command = 'ls -1aF "' // trim(expanded_dir) // '/" 2>/dev/null | grep -i "^' // &
-        trim(pattern) // '"'
-    else
-      ls_command = 'ls -1aF "' // trim(expanded_dir) // '/" 2>/dev/null'
-    end if
-
-    ! Debug output
-    if (debug_enabled) then
-    end if
-
-    ! Get output from command — use tab-delimited capture to preserve spaces in filenames
-    ls_output_alloc = execute_and_capture_tabs(ls_command)
-
-    ! Copy to fixed buffer (avoids flang-new issues with allocatable strings)
-    ls_output = ls_output_alloc(:min(len(ls_output), len(ls_output_alloc)))
-
-    ! Clean up allocatable
-    if (allocated(ls_output_alloc)) deallocate(ls_output_alloc)
-
-    ! Parse ls output — tab-delimited to preserve spaces in filenames
-    call parse_ls_output(ls_output, entries, num_entries, use_tab_delim=.true.)
-
-    ! Debug output
-    if (debug_enabled) then
-    end if
+    ! Enumerate the directory natively via opendir/readdir — no `ls` subprocess.
+    ! This removes shell injection, dependence on the host `ls`/locale, and (the
+    ! bug that started this) any chance of a subprocess printing onto the
+    ! terminal mid-redraw. readdir reports directory-ness directly (symlinks to
+    ! directories are followed). Pattern matching stays below in fuzzy_match_score.
+    allocate(entries(MAX_DIR_ENTRIES), is_dir_flags(MAX_DIR_ENTRIES))
+    call list_directory(trim(expanded_dir), entries, is_dir_flags, num_entries)
 
     ! Score entries using fuzzy matching
     num_scored = 0
     do i = 1, num_entries
       if (num_scored >= MAX_SCORED_ITEMS) exit
 
-      ! Skip . and .. unless explicitly requested (ls -F adds / to these too)
-      if (trim(entries(i)) == './' .or. trim(entries(i)) == '../' .or. &
-          trim(entries(i)) == '.' .or. trim(entries(i)) == '..') then
+      ! Skip . and .. unless the user explicitly typed a leading dot
+      if (trim(entries(i)) == '.' .or. trim(entries(i)) == '..') then
         if (pattern_len == 0 .or. (pattern_len > 0 .and. pattern(1:1) /= '.')) then
           cycle
         end if
       end if
 
-      ! Check if entry is a directory (ls -F adds / to directories)
-      is_dir = .false.
-      if (len_trim(entries(i)) > 0) then
-        if (entries(i)(len_trim(entries(i)):len_trim(entries(i))) == '/') then
-          is_dir = .true.
-          ! Remove the trailing / for matching
-          full_path = entries(i)(:len_trim(entries(i))-1)
-        else
-          ! Remove executable markers (*) and other ls -F markers (@, =, |, %)
-          if (index('*@=|%', entries(i)(len_trim(entries(i)):len_trim(entries(i)))) > 0) then
-            full_path = entries(i)(:len_trim(entries(i))-1)
-          else
-            full_path = trim(entries(i))
-          end if
-        end if
-      else
-        full_path = trim(entries(i))
-      end if
+      ! Directory-ness comes straight from readdir; the name is already clean
+      ! (no ls -F markers to strip).
+      is_dir = is_dir_flags(i)
+      full_path = trim(entries(i))
 
-      ! Calculate fuzzy match score (without the ls -F marker)
+      ! Calculate fuzzy match score
       score = fuzzy_match_score(pattern, trim(full_path))
       if (score >= 0) then  ! Negative score = no match
         ! Build full path for display (use original dir_path to preserve ~ in display)
@@ -4100,19 +4050,9 @@ contains
     ! Clean up allocatable arrays
     if (allocated(scored)) deallocate(scored)
     if (allocated(entries)) deallocate(entries)
+    if (allocated(is_dir_flags)) deallocate(is_dir_flags)
   end subroutine
 
-  ! Check if a path is a directory
-  function is_directory(path) result(is_dir)
-    character(len=*), intent(in) :: path
-    logical :: is_dir
-    character(len=MAX_LINE_LEN) :: test_command, output
-
-    ! Use test command to check if path is a directory
-    test_command = 'test -d "' // trim(path) // '" && echo "yes" || echo "no"'
-    output = execute_and_capture(test_command)
-    is_dir = (index(output, 'yes') > 0)
-  end function
 
   ! Parse ls output into individual entries
   subroutine parse_ls_output(output, entries, num_entries, use_tab_delim)

--- a/src/parsing/glob.f90
+++ b/src/parsing/glob.f90
@@ -208,182 +208,92 @@ contains
     character(len=MAX_TOKEN_LEN), intent(out) :: matches(:)
     integer, intent(out) :: match_count
 
-    ! Simple implementation - in a full shell this would use opendir/readdir
     ! Use allocatable to avoid stack overflow on macOS
-    character(len=MAX_FILENAME_LEN), allocatable :: test_files(:)
+    character(len=MAX_FILENAME_LEN), allocatable :: dir_entries(:)
     integer :: num_test_files, i
 
     match_count = 0
-    allocate(test_files(10000))  ! Increased to handle directories with many files
+    allocate(dir_entries(10000))  ! handle directories with many files
 
-    ! For now, simulate some common files for testing
-    ! In a real implementation, this would read the actual directory
-    call get_simulated_directory_contents(dir_path, test_files, num_test_files)
+    ! Read the actual directory natively (opendir/readdir, no `ls` subprocess)
+    call list_directory_entries(dir_path, dir_entries, num_test_files)
     
     do i = 1, num_test_files
-      if (pattern_matches(file_pattern, test_files(i))) then
+      if (pattern_matches(file_pattern, dir_entries(i))) then
         if (match_count < size(matches)) then
           match_count = match_count + 1
           if (include_dir_path) then
             if (trim(dir_path) == '.') then
-              matches(match_count) = trim(test_files(i))
+              matches(match_count) = trim(dir_entries(i))
             else
-              matches(match_count) = trim(dir_path) // '/' // trim(test_files(i))
+              matches(match_count) = trim(dir_path) // '/' // trim(dir_entries(i))
             end if
           else
-            matches(match_count) = trim(test_files(i))
+            matches(match_count) = trim(dir_entries(i))
           end if
         end if
       end if
     end do
 
-    if (allocated(test_files)) deallocate(test_files)
+    ! POSIX: pathname expansion results are sorted. readdir returns entries in
+    ! directory order, so sort here (the old `ls`-based path got this for free).
+    call sort_strings(matches, match_count)
+
+    if (allocated(dir_entries)) deallocate(dir_entries)
   end subroutine
 
-  ! Get actual directory contents (simplified implementation)
-  subroutine get_simulated_directory_contents(dir_path, files, count)
+  ! In-place ascending sort of the first n elements (insertion sort — match sets
+  ! are typically small, and glob runs at command time, not per keystroke).
+  subroutine sort_strings(arr, n)
+    character(len=*), intent(inout) :: arr(:)
+    integer, intent(in) :: n
+    integer :: i, j
+    character(len=len(arr)) :: key
+    do i = 2, n
+      key = arr(i)
+      j = i - 1
+      do while (j >= 1)
+        if (arr(j) <= key) exit
+        arr(j+1) = arr(j)
+        j = j - 1
+      end do
+      arr(j+1) = key
+    end do
+  end subroutine
+
+  ! Get actual directory contents via native opendir/readdir (no `ls` subprocess).
+  ! Returns every entry except "." and ".." (matching the old `ls -A1`); the
+  ! caller's pattern_matches decides what actually matches (and enforces the
+  ! POSIX rule that * / ? don't match leading-dot files).
+  subroutine list_directory_entries(dir_path, files, count)
     character(len=*), intent(in) :: dir_path
     character(len=MAX_FILENAME_LEN), intent(out) :: files(:)
     integer, intent(out) :: count
-    
-    ! For now, keep simulation but add note
-    ! In a production shell, this would use opendir/readdir system calls
-    ! or execute 'ls' and parse output
-    
-    ! Try to read actual directory via ls command
-    call read_directory_with_ls(dir_path, files, count)
 
-    ! No fallback simulation - if ls returns nothing, return nothing
-  end subroutine
-
-  ! Read directory contents using ls command
-  subroutine read_directory_with_ls(dir_path, files, count)
-    character(len=*), intent(in) :: dir_path
-    character(len=MAX_FILENAME_LEN), intent(out) :: files(:)
-    integer, intent(out) :: count
-
-    ! Increased buffer size to handle directories with many files (like /tmp)
-    integer, parameter :: BUFFER_SIZE = 524288  ! 512KB buffer for large directories
-
-    character(len=512) :: command
-    integer(c_pid_t) :: pid
-    integer(c_int), target :: status, pipefd(2)
-    integer :: ret, i, line_start, total_bytes
-    character(len=BUFFER_SIZE), allocatable :: buffer
-    integer(c_size_t) :: bytes_read
-    character(kind=c_char), target :: c_buffer(8192)  ! Read in 8KB chunks
+    character(len=MAX_FILENAME_LEN), allocatable :: raw(:)
+    logical, allocatable :: is_dir_flags(:)
+    integer :: nraw, i, cap
 
     count = 0
-    allocate(character(len=BUFFER_SIZE) :: buffer)
+    cap = size(files)
+    if (cap <= 0) return
 
-    ! Construct ls command (-A excludes . and .., -1 means one per line)
-    if (trim(dir_path) == '.' .or. trim(dir_path) == '') then
-      command = 'ls -A1 2>/dev/null'
+    ! +2 headroom so dropping "." and ".." never costs a real entry
+    allocate(raw(cap + 2), is_dir_flags(cap + 2))
+    if (trim(dir_path) == '') then
+      call list_directory('.', raw, is_dir_flags, nraw)
     else
-      command = 'ls -A1 ' // trim(dir_path) // ' 2>/dev/null'
+      call list_directory(trim(dir_path), raw, is_dir_flags, nraw)
     end if
 
-    ! Create pipe for reading output
-    ret = c_pipe(c_loc(pipefd))
-    if (ret /= 0) return
-
-    ! Fork to execute ls
-    pid = c_fork()
-
-    if (pid == 0) then
-      ! Child: redirect stdout to pipe and execute ls
-      ret = c_close(pipefd(1))  ! Close read end
-      ret = c_dup2(pipefd(2), STDOUT_FD)
-      ret = c_close(pipefd(2))  ! Close original write end
-
-      ! Execute ls via shell
-      call execute_ls_command(trim(command))
-      call c_exit(127)
-    else if (pid > 0) then
-      ! Parent: read from pipe
-      ret = c_close(pipefd(2))  ! Close write end
-
-      ! Read output from pipe in chunks until EOF
-      buffer = ''
-      total_bytes = 0
-      do
-        bytes_read = c_read(pipefd(1), c_loc(c_buffer), int(8192, c_size_t))
-        if (bytes_read <= 0) exit  ! EOF or error
-
-        ! Append to buffer
-        do i = 1, min(int(bytes_read), 8192)
-          if (c_buffer(i) == c_null_char) exit
-          if (total_bytes < BUFFER_SIZE) then
-            total_bytes = total_bytes + 1
-            buffer(total_bytes:total_bytes) = c_buffer(i)
-          end if
-        end do
-
-        ! Stop if buffer is full
-        if (total_bytes >= BUFFER_SIZE) exit
-      end do
-
-      ! Parse lines from buffer
-      line_start = 1
-      do i = 1, total_bytes
-        if (buffer(i:i) == char(10)) then  ! Newline
-          if (i > line_start .and. count < size(files)) then
-            count = count + 1
-            files(count) = buffer(line_start:i-1)
-          end if
-          line_start = i + 1
-        end if
-      end do
-
-      ! Handle last line if no trailing newline
-      if (line_start <= total_bytes .and. count < size(files)) then
-        count = count + 1
-        files(count) = buffer(line_start:total_bytes)
-      end if
-
-      ret = c_close(pipefd(1))
-      ret = c_waitpid(pid, c_loc(status), 0)
-    end if
-  end subroutine
-
-  ! Execute ls command via shell
-  subroutine execute_ls_command(command)
-    character(len=*), intent(in) :: command
-    character(kind=c_char), target :: shell_path(10)
-    character(kind=c_char), target :: c_flag(3)
-    character(kind=c_char), target :: c_command(512)
-    type(c_ptr), target :: argv(4)
-    integer :: i, ret
-
-    ! Prepare /bin/sh
-    shell_path(1) = '/'
-    shell_path(2) = 'b'
-    shell_path(3) = 'i'
-    shell_path(4) = 'n'
-    shell_path(5) = '/'
-    shell_path(6) = 's'
-    shell_path(7) = 'h'
-    shell_path(8) = c_null_char
-
-    ! Prepare -c flag
-    c_flag(1) = '-'
-    c_flag(2) = 'c'
-    c_flag(3) = c_null_char
-
-    ! Prepare command string
-    do i = 1, min(len_trim(command), 500)
-      c_command(i) = command(i:i)
+    do i = 1, nraw
+      if (trim(raw(i)) == '.' .or. trim(raw(i)) == '..') cycle
+      if (count >= cap) exit
+      count = count + 1
+      files(count) = raw(i)
     end do
-    c_command(min(len_trim(command), 500) + 1) = c_null_char
 
-    ! Setup argv: ["/bin/sh", "-c", command, NULL]
-    argv(1) = c_loc(shell_path)    ! /bin/sh
-    argv(2) = c_loc(c_flag)        ! -c
-    argv(3) = c_loc(c_command)     ! command
-    argv(4) = c_null_ptr
-
-    ! Execute
-    ret = c_execvp(argv(1), c_loc(argv))
+    deallocate(raw, is_dir_flags)
   end subroutine
 
   ! Check if a filename matches a glob pattern

--- a/src/system/interface.f90
+++ b/src/system/interface.f90
@@ -563,7 +563,29 @@ module system_interface
       integer(c_int), value :: timeout
       integer(c_int) :: c_poll
     end function
-    
+
+    ! Native directory enumeration (src/c_interop/fortsh_dir.c) — replaces
+    ! shelling out to `ls`. The C side owns the platform-specific struct dirent.
+    function c_opendir(path) bind(C, name="fortsh_opendir")
+      import :: c_ptr, c_char
+      character(kind=c_char), intent(in) :: path(*)
+      type(c_ptr) :: c_opendir
+    end function
+
+    function c_readdir(dirp, name_buf, buf_len, is_dir) bind(C, name="fortsh_readdir")
+      import :: c_ptr, c_char, c_int
+      type(c_ptr), value :: dirp
+      character(kind=c_char), intent(inout) :: name_buf(*)
+      integer(c_int), value :: buf_len
+      integer(c_int), intent(out) :: is_dir
+      integer(c_int) :: c_readdir
+    end function
+
+    subroutine c_closedir(dirp) bind(C, name="fortsh_closedir")
+      import :: c_ptr
+      type(c_ptr), value :: dirp
+    end subroutine
+
     subroutine c_cfmakeraw(termios_p) bind(C, name="cfmakeraw")
       import :: termios_t
       type(termios_t), intent(inout) :: termios_p
@@ -1327,6 +1349,60 @@ contains
     ret = c_poll(c_loc(pfd), 1_c_int, 0_c_int)
     pending = (ret > 0 .and. iand(int(pfd%revents), int(POLLIN)) /= 0)
   end function input_pending
+
+  ! Native directory listing via opendir/readdir (no `ls` subprocess).
+  ! Fills the caller's names()/is_dir_flags() arrays (up to their size) with the
+  ! raw directory entries — including "." and ".." — leaving any pattern
+  ! matching to the caller. `count` is the number of entries returned.
+  subroutine list_directory(path, names, is_dir_flags, count)
+    character(len=*), intent(in)    :: path
+    character(len=*), intent(inout) :: names(:)
+    logical,          intent(out)   :: is_dir_flags(:)
+    integer,          intent(out)   :: count
+
+    integer, parameter :: NAME_BUF_LEN = 1024
+    type(c_ptr) :: dirp
+    character(kind=c_char) :: cpath(len_trim(path) + 1)
+    character(kind=c_char) :: namebuf(NAME_BUF_LEN)
+    integer(c_int) :: is_dir, rc
+    integer :: i, plen, maxn, namelen
+
+    count = 0
+    maxn = min(size(names), size(is_dir_flags))
+    if (maxn <= 0) return
+
+    ! Build a NUL-terminated C path
+    plen = len_trim(path)
+    do i = 1, plen
+      cpath(i) = path(i:i)
+    end do
+    cpath(plen + 1) = c_null_char
+
+    dirp = c_opendir(cpath)
+    if (.not. c_associated(dirp)) return
+
+    do
+      if (count >= maxn) exit
+      rc = c_readdir(dirp, namebuf, int(NAME_BUF_LEN, c_int), is_dir)
+      if (rc /= 1) exit
+
+      ! Length of the NUL-terminated name returned by C
+      namelen = 0
+      do i = 1, NAME_BUF_LEN
+        if (namebuf(i) == c_null_char) exit
+        namelen = namelen + 1
+      end do
+
+      count = count + 1
+      names(count) = ''
+      do i = 1, min(namelen, len(names(count)))
+        names(count)(i:i) = namebuf(i)
+      end do
+      is_dir_flags(count) = (is_dir /= 0)
+    end do
+
+    call c_closedir(dirp)
+  end subroutine list_directory
 
   ! Get current process ID
   function get_pid() result(pid)


### PR DESCRIPTION
## The bug

Typing a backslash (or any char that breaks a grep regex / an unmatched `[`) made **every subsequent keystroke duplicate the prompt** on screen. Root cause: tab-completion/autosuggestion shelled out to `ls -1aF "dir" | grep -i "^pattern"`. The `ls` had its stderr redirected but the **`grep` did not**, so `grep: trailing backslash (\)` printed onto the terminal mid-redraw, pushing the cursor down a line so the prompt was never overwritten.

The same code path also spliced the raw typed word into the shell command, which was a **command-injection on every keystroke** (verified: typing `$(touch …)` as a path word executed it).

## The fix — go native (bespoke-shell goal)

A shell shouldn't fork `ls` to read a directory. Added native `opendir`/`readdir`/`closedir` via a small C helper (`src/c_interop/fortsh_dir.c`, same pattern as `fd_wrapper.c` — the C side owns `struct dirent`), exposed as `list_directory()` in `system_interface`, and routed all directory enumeration through it:

- **Tab completion** (`scan_directory`) — was `ls | grep`
- **Glob tab-completion** (`expand_glob_for_completion`) — was `ls` + a `test -d` subprocess per entry
- **Core globbing `*.txt`** (`glob.f90`) — was a hand-rolled fork/exec/pipe of `ls -A1`

Deleted: the `ls|grep` builder, `is_directory()` (`test -d`), and glob's fork/exec/pipe `ls` machinery. Glob results are now sorted in-process (POSIX requires sorted pathname expansion; `ls` had provided that for free).

This removes the subprocess-output-leak bug class, the injection, and the dependence on the host `ls`/`grep`/locale — readdir reports directory-ness directly (symlinks to dirs followed).

## Tests

- **Full POSIX suite: 3776/3776 (25/25 suites), 0 failures** — glob heavily exercised.
- Interactive: completion 36/0, line_editing 49/0.
- Repro fixed: backslash → 1 prompt (was N); `$(touch …)` no longer executes; glob output matches bash exactly (incl. sorting and the dotfile rule).
- dev / release (O2) / debug (`-fcheck=bounds`) all build clean (Linux + FreeBSD flags).

Remaining shell-outs are intentional/benign: `git` (external tool, prompt), clipboard `pbcopy`/`xclip` (no syscall alternative). Follow-up candidates noted: `env`-based `$VAR` completion and `tput` size (redundant with the existing TIOCGWINSZ ioctl).