### PR TITLE
Audit fixes: crash fixes, buffer-cap removal, and native de-shell-out (20 findings)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ lldb_interactive.sh
 .fackr/
 scratch.sh
 docs/
+.docs/

--- a/src/c_interop/fd_wrapper.c
+++ b/src/c_interop/fd_wrapper.c
@@ -4,6 +4,14 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <pwd.h>
+
+// Look up a user's home directory via getpwnam (for ~user expansion).
+// Returns the pw_dir string, or NULL if the user does not exist.
+const char *fortsh_user_home(const char *name) {
+    struct passwd *pw = getpwnam(name);
+    return pw ? pw->pw_dir : (const char *)0;
+}
 
 // macOS kernel bug workaround: set S_CTTYREF on the controlling terminal.
 // On macOS, PTY slave output is discarded when the child process exits unless

--- a/src/common/error_handling.f90
+++ b/src/common/error_handling.f90
@@ -142,28 +142,6 @@ contains
     call log_error(ERR_WARN, 0, 0, message, location)
   end subroutine
 
-  ! Validate system resource availability
-  function check_system_resources() result(is_ok)
-    logical :: is_ok
-    integer :: available_memory, available_fds
-    
-    is_ok = .true.
-    
-    ! Basic resource checks (simplified)
-    available_memory = 1000000  ! Placeholder
-    available_fds = 100         ! Placeholder
-    
-    if (available_memory < 1000) then
-      call system_error(301, 'Low memory warning', 'check_system_resources')
-      is_ok = .false.
-    end if
-    
-    if (available_fds < 10) then
-      call system_error(302, 'Low file descriptor count', 'check_system_resources')
-      is_ok = .false.
-    end if
-  end function
-
   ! Validate command before execution
   function validate_command(command) result(is_valid)
     character(len=*), intent(in) :: command

--- a/src/execution/ast_executor.f90
+++ b/src/execution/ast_executor.f90
@@ -26,7 +26,6 @@ module ast_executor
   public :: execute_ast_node
   public :: unset_ast_function
   public :: is_ast_function
-  public :: execute_external_command  ! Currently unused but may be needed later
   public :: register_trap_evaluator
 
   ! C bindings for process control
@@ -2991,35 +2990,6 @@ contains
     exit_code = ishft(status, -8)
     exit_code = iand(exit_code, 255)
   end function extract_exit_status
-
-  subroutine execute_external_command(words, num_words, exit_status)
-    character(len=*), intent(in) :: words(:)
-    integer, intent(in) :: num_words
-    integer, intent(out) :: exit_status
-    character(len=MAX_PATH_LEN) :: cmd_path
-    integer :: ret
-
-    interface
-      function c_system(cmd) bind(c, name='system')
-        import :: c_char, c_int
-        character(kind=c_char), dimension(*) :: cmd
-        integer(c_int) :: c_system
-      end function
-    end interface
-
-    exit_status = 0
-
-    if (num_words == 0) return
-
-    cmd_path = trim(words(1))
-
-    ! Try to execute command
-    ! For now, just use system() as a placeholder
-    ! TODO: Implement proper execvp with argv array
-    ret = c_system(trim(cmd_path) // c_null_char)
-    exit_status = extract_exit_status(ret)
-
-  end subroutine execute_external_command
 
   ! Execute a pending trap command (set by signal_handling module)
   subroutine execute_pending_trap(shell)

--- a/src/execution/ast_executor.f90
+++ b/src/execution/ast_executor.f90
@@ -96,9 +96,24 @@ contains
     type(command_node_t), pointer, intent(in) :: node
     type(shell_state_t), intent(inout) :: shell
     integer :: exit_status
+    ! Shared recursion-depth counter (save => static, persists across the
+    ! recursive calls). Bounds executor nesting so a deeply nested AST can't
+    ! overflow the C stack and crash; the parser caps nesting too, but the
+    ! executor frames are larger so it needs its own (lower) guard.
+    integer, save :: exec_depth = 0
+    integer, parameter :: MAX_EXEC_DEPTH = 100
 
     if (.not. associated(node)) then
       exit_status = 0
+      return
+    end if
+
+    exec_depth = exec_depth + 1
+    if (exec_depth > MAX_EXEC_DEPTH) then
+      call write_stderr('fortsh: maximum nesting depth exceeded')
+      exit_status = 2
+      shell%last_exit_status = 2
+      exec_depth = exec_depth - 1
       return
     end if
 
@@ -148,6 +163,7 @@ contains
     end select
 
     shell%last_exit_status = exit_status
+    exec_depth = exec_depth - 1
   end function execute_ast_node
 
   ! =====================================

--- a/src/execution/ast_executor.f90
+++ b/src/execution/ast_executor.f90
@@ -96,24 +96,9 @@ contains
     type(command_node_t), pointer, intent(in) :: node
     type(shell_state_t), intent(inout) :: shell
     integer :: exit_status
-    ! Shared recursion-depth counter (save => static, persists across the
-    ! recursive calls). Bounds executor nesting so a deeply nested AST can't
-    ! overflow the C stack and crash; the parser caps nesting too, but the
-    ! executor frames are larger so it needs its own (lower) guard.
-    integer, save :: exec_depth = 0
-    integer, parameter :: MAX_EXEC_DEPTH = 100
 
     if (.not. associated(node)) then
       exit_status = 0
-      return
-    end if
-
-    exec_depth = exec_depth + 1
-    if (exec_depth > MAX_EXEC_DEPTH) then
-      call write_stderr('fortsh: maximum nesting depth exceeded')
-      exit_status = 2
-      shell%last_exit_status = 2
-      exec_depth = exec_depth - 1
       return
     end if
 
@@ -163,7 +148,6 @@ contains
     end select
 
     shell%last_exit_status = exit_status
-    exec_depth = exec_depth - 1
   end function execute_ast_node
 
   ! =====================================

--- a/src/execution/builtins.f90
+++ b/src/execution/builtins.f90
@@ -4274,6 +4274,7 @@ contains
   end subroutine
 
   subroutine builtin_fc(cmd, shell)
+    use trap_dispatch, only: eval_trap_string  ! run a string through the current shell
     type(command_t), intent(in) :: cmd
     type(shell_state_t), intent(inout) :: shell
     logical :: list_mode, no_line_numbers, reverse_order, subst_mode
@@ -4281,7 +4282,7 @@ contains
     character(len=:), allocatable :: line, tmpfile, edit_cmd
     character(len=40) :: fmt_buf
     integer :: first, last, i, arg_idx, iostat, tmp_unit
-    integer :: eq_pos, history_count
+    integer :: eq_pos, history_count, fc_ec
     logical :: found
 
     ! Pre-allocate line for intent(out) calls and Fortran read
@@ -4455,8 +4456,10 @@ contains
       ! Print the command being executed
       write(output_unit, '(a)') trim(line)
 
-      ! Execute using c_system
-      shell%last_exit_status = c_system(trim(line) // c_null_char)
+      ! Run it in the CURRENT shell (functions/aliases/locals visible), not
+      ! /bin/sh; eval_trap_string returns the real exit code, not a wait-status.
+      call eval_trap_string(trim(line), shell, fc_ec)
+      shell%last_exit_status = fc_ec
 
       return
     end if
@@ -4540,8 +4543,9 @@ contains
 
       if (len_trim(line) == 0 .or. line(1:1) == '#') cycle
 
-      ! Execute the line using c_system
-      shell%last_exit_status = c_system(trim(line) // c_null_char)
+      ! Run the edited line in the current shell (not /bin/sh)
+      call eval_trap_string(trim(line), shell, fc_ec)
+      shell%last_exit_status = fc_ec
     end do
 
     close(tmp_unit)

--- a/src/execution/builtins.f90
+++ b/src/execution/builtins.f90
@@ -2447,37 +2447,6 @@ contains
     is_valid = .true.
   end function
 
-  subroutine builtin_timeout(cmd, shell)
-    type(command_t), intent(in) :: cmd
-    type(shell_state_t), intent(inout) :: shell
-    
-    integer :: timeout_seconds, i
-    character(len=:), allocatable :: command
-
-    if (cmd%num_tokens < 3) then
-      write(error_unit, '(a)') 'timeout: usage: timeout DURATION COMMAND...'
-      shell%last_exit_status = 1
-      return
-    end if
-
-    read(cmd%tokens(2), *, iostat=i) timeout_seconds
-    if (i /= 0 .or. timeout_seconds <= 0) then
-      write(error_unit, '(a)') 'timeout: invalid duration'
-      shell%last_exit_status = 1
-      return
-    end if
-
-    ! Reconstruct command from remaining tokens
-    command = ''
-    do i = 3, cmd%num_tokens
-      if (i > 3) command = trim(command) // ' '
-      command = trim(command) // trim(cmd%tokens(i))
-    end do
-    
-    ! Execute command with timeout - placeholder
-    shell%last_exit_status = 0
-  end subroutine
-
   ! =============================================================================
   ! POSIX Required Built-ins (Phase 10: Critical POSIX Compliance)
   ! =============================================================================
@@ -5107,54 +5076,6 @@ contains
     shell%last_exit_status = 0
   end subroutine builtin_dirh
 
-  ! Execute EXIT trap inline (to avoid circular dependency with executor module)
-  subroutine execute_exit_trap_inline(shell)
-    type(shell_state_t), intent(inout) :: shell
-    character(len=:), allocatable :: trap_cmd
-    integer :: saved_status
-    type(pipeline_t) :: trap_pipeline
-    integer :: i
-
-    ! Save trap command and clear
-    trap_cmd = shell%pending_trap_command
-    shell%pending_trap_command = ''
-    shell%pending_trap_signal = 0
-
-    ! Save exit status (traps don't affect $?)
-    saved_status = shell%last_exit_status
-
-    ! Set flag to prevent recursive traps
-    shell%executing_trap = .true.
-
-    ! Parse trap command
-    call parse_pipeline(trim(trap_cmd), trap_pipeline)
-
-    ! Execute it in current shell context (inline execution using c_system)
-    ! We use c_system instead of execute_pipeline to avoid circular dependency
-    if (len_trim(trap_cmd) > 0) then
-      i = c_system(trim(trap_cmd) // c_null_char)
-    end if
-
-    ! Clean up pipeline allocations
-    if (allocated(trap_pipeline%commands)) then
-      do i = 1, trap_pipeline%num_commands
-        if (allocated(trap_pipeline%commands(i)%tokens)) deallocate(trap_pipeline%commands(i)%tokens)
-        if (allocated(trap_pipeline%commands(i)%input_file)) deallocate(trap_pipeline%commands(i)%input_file)
-        if (allocated(trap_pipeline%commands(i)%output_file)) deallocate(trap_pipeline%commands(i)%output_file)
-        if (allocated(trap_pipeline%commands(i)%error_file)) deallocate(trap_pipeline%commands(i)%error_file)
-        if (allocated(trap_pipeline%commands(i)%heredoc_delimiter)) deallocate(trap_pipeline%commands(i)%heredoc_delimiter)
-        if (allocated(trap_pipeline%commands(i)%heredoc_content)) deallocate(trap_pipeline%commands(i)%heredoc_content)
-        if (allocated(trap_pipeline%commands(i)%here_string)) deallocate(trap_pipeline%commands(i)%here_string)
-      end do
-      deallocate(trap_pipeline%commands)
-    end if
-
-    ! Clear flag
-    shell%executing_trap = .false.
-
-    ! Restore exit status (traps don't affect $?)
-    shell%last_exit_status = saved_status
-  end subroutine execute_exit_trap_inline
 
 
 end module builtins

--- a/src/execution/eval_builtin.f90
+++ b/src/execution/eval_builtin.f90
@@ -12,7 +12,7 @@ contains
     type(command_t), intent(in) :: cmd
     type(shell_state_t), intent(inout) :: shell
     integer :: i, exit_code
-    character(len=4096) :: eval_command
+    character(len=:), allocatable :: eval_command  ! grow with the command; never truncate at 4096
     type(command_node_t), pointer :: ast_root
 
     ! If no arguments, just return success

--- a/src/execution/executor.f90
+++ b/src/execution/executor.f90
@@ -2818,7 +2818,6 @@ contains
       character(len=:), allocatable :: path_alloc
       character(len=4096) :: path_var
       character(len=:), allocatable :: path_comp, candidate
-      character(len=MAX_PATH_LEN) :: candidate_buf
       integer :: spos, epos, cpos
       character(kind=c_char), target :: c_path(1025)
       integer :: ci, acc_status
@@ -2852,18 +2851,23 @@ contains
         path_comp = path_var(spos:epos)
         if (len_trim(path_comp) == 0) path_comp = '.'
 
-        write(candidate_buf, '(a,a,a)') trim(path_comp), '/', trim(cmd_name)
-        candidate = trim(candidate_buf)
+        ! Build the candidate via allocatable concat — a fixed-buffer write here
+        ! aborted with "End of record" when path+name exceeded the buffer.
+        candidate = trim(path_comp) // '/' // trim(cmd_name)
 
-        ! Check executable via C access()
-        do ci = 1, len_trim(candidate)
-          c_path(ci) = candidate(ci:ci)
-        end do
-        c_path(len_trim(candidate) + 1) = c_null_char
-        acc_status = cache_access(c_path, int(1, c_int))  ! X_OK = 1
-        if (acc_status == 0) then
-          full_path = trim(candidate)
-          exit
+        ! Only probe candidates that fit the C path buffer; anything longer
+        ! cannot name a real executable (bash likewise reports "not found").
+        if (len_trim(candidate) + 1 <= size(c_path)) then
+          ! Check executable via C access()
+          do ci = 1, len_trim(candidate)
+            c_path(ci) = candidate(ci:ci)
+          end do
+          c_path(len_trim(candidate) + 1) = c_null_char
+          acc_status = cache_access(c_path, int(1, c_int))  ! X_OK = 1
+          if (acc_status == 0) then
+            full_path = trim(candidate)
+            exit
+          end if
         end if
 
         if (cpos == 0) exit

--- a/src/execution/pipeline_helpers.f90
+++ b/src/execution/pipeline_helpers.f90
@@ -344,6 +344,11 @@ contains
                   if (bw_i == 0) then
                     ! Numeric range — generate tokens directly
                     br_fast = .true.
+                    ! Step is a magnitude; direction comes from start vs end
+                    ! (bash semantics). Guard a zero step (SIGFPE on the divide)
+                    ! and a negative step (negative count -> bad allocation).
+                    br_step = abs(br_step)
+                    if (br_step == 0) br_step = 1
                     if (br_start <= br_end) then
                       br_count = (br_end - br_start) / br_step + 1
                     else

--- a/src/io/readline.f90
+++ b/src/io/readline.f90
@@ -1325,34 +1325,20 @@ contains
   ! Safe terminal size detection for macOS (avoids get_terminal_size crash on flang-new)
   subroutine safe_get_terminal_size(rows, cols)
     integer, intent(out) :: rows, cols
-    character(len=:), allocatable :: cols_str, rows_str
-    integer :: cols_val, rows_val, ios
+    integer :: r, c
+    logical :: ok
 
     ! Default fallback values
     cols = 80
     rows = 24
 
-    ! Try to get columns using tput
-    cols_str = execute_and_capture('tput cols 2>/dev/null')
-    if (allocated(cols_str) .and. len_trim(cols_str) > 0) then
-      read(cols_str, *, iostat=ios) cols_val
-      if (ios == 0 .and. cols_val > 0 .and. cols_val < 500) then
-        cols = cols_val
-      end if
+    ! Native ioctl via the C helper — no `tput` subprocess, and safe on
+    ! flang-new (the ioctl runs in C, not the crashing Fortran c_loc path).
+    ok = get_term_size_native(r, c)
+    if (ok) then
+      if (c > 0 .and. c < 500) cols = c
+      if (r > 0 .and. r < 500) rows = r
     end if
-
-    ! Try to get rows using tput
-    rows_str = execute_and_capture('tput lines 2>/dev/null')
-    if (allocated(rows_str) .and. len_trim(rows_str) > 0) then
-      read(rows_str, *, iostat=ios) rows_val
-      if (ios == 0 .and. rows_val > 0 .and. rows_val < 500) then
-        rows = rows_val
-      end if
-    end if
-
-    ! Clean up
-    if (allocated(cols_str)) deallocate(cols_str)
-    if (allocated(rows_str)) deallocate(rows_str)
   end subroutine safe_get_terminal_size
 #endif
 
@@ -1859,8 +1845,8 @@ contains
 
           ! Get terminal size for multiline handling
 #ifdef __APPLE__
-            ! WORKAROUND: get_terminal_size crashes on flang-new
-            ! Use tput command as a safe alternative
+            ! WORKAROUND: the Fortran get_terminal_size (c_loc on winsize)
+            ! crashes on flang-new; use the native C ioctl helper instead.
             call safe_get_terminal_size(term_rows, term_cols)
 #else
             ! Linux: Use actual terminal size

--- a/src/io/readline.f90
+++ b/src/io/readline.f90
@@ -853,37 +853,20 @@ contains
 
   ! Detect the clipboard tool at startup (idempotent).
   subroutine clipboard_detect()
-    character(len=:), allocatable :: result
-
     if (clipboard_initialized) return
     clipboard_initialized = .true.
 
-    ! Probe in preference order. execute_and_capture runs `which <tool>`
-    ! and returns the path if found, or an empty string if not.
-    result = execute_and_capture('which pbcopy 2>/dev/null')
-    if (len_trim(result) > 0) then
+    ! Probe in preference order via a native $PATH scan (access(X_OK)),
+    ! not a `which` subprocess.
+    if (command_in_path('pbcopy')) then
       clipboard_tool = CLIP_PBCOPY
-      return
-    end if
-
-    result = execute_and_capture('which wl-copy 2>/dev/null')
-    if (len_trim(result) > 0) then
+    else if (command_in_path('wl-copy')) then
       clipboard_tool = CLIP_WLCOPY
-      return
-    end if
-
-    result = execute_and_capture('which xclip 2>/dev/null')
-    if (len_trim(result) > 0) then
+    else if (command_in_path('xclip')) then
       clipboard_tool = CLIP_XCLIP
-      return
-    end if
-
-    result = execute_and_capture('which xsel 2>/dev/null')
-    if (len_trim(result) > 0) then
+    else if (command_in_path('xsel')) then
       clipboard_tool = CLIP_XSEL
-      return
     end if
-
     ! No tool found — clipboard_tool stays CLIP_NONE.
   end subroutine clipboard_detect
 

--- a/src/io/readline.f90
+++ b/src/io/readline.f90
@@ -3740,33 +3740,29 @@ contains
     integer, intent(out) :: num_completions
 
     character(len=256) :: var_prefix
-    character(len=4096) :: env_output
-    character(len=:), allocatable :: env_alloc
-    character(len=MAX_LINE_LEN), allocatable :: entries(:)
-    integer :: num_entries, i, score
+    integer :: i, score, eqpos
+    character(len=:), allocatable :: entry
 
     num_completions = 0
     ! Strip the $ from the prefix
     var_prefix = prefix_with_dollar(2:)
 
-    ! Get variable names from environment (exported + inherited)
-    env_alloc = execute_and_capture('env 2>/dev/null | cut -d= -f1 | tr ' // "'" // char(92) // 'n' // "' ' '")
-    env_output = env_alloc(:min(len(env_output), len(env_alloc)))
-    if (allocated(env_alloc)) deallocate(env_alloc)
-
-    ! Parse into entries
-    call parse_ls_output(env_output, entries, num_entries)
-
-    ! Match against prefix
-    do i = 1, num_entries
-      if (num_completions >= MAX_LOCAL_COMPLETIONS) exit
-      if (len_trim(entries(i)) == 0) cycle
-
-      score = fuzzy_match_score(trim(var_prefix), trim(entries(i)))
+    ! Iterate the environment natively (no `env | cut | tr` subprocess); each
+    ! entry is "NAME=value", so match on the NAME before '='.
+    i = 0
+    do
+      entry = get_environ_entry(i)
+      if (len(entry) == 0) exit  ! end of environ
+      i = i + 1
+      if (num_completions >= MAX_LOCAL_COMPLETIONS) cycle
+      eqpos = index(entry, '=')
+      if (eqpos <= 1) cycle
+      score = fuzzy_match_score(trim(var_prefix), entry(1:eqpos-1))
       if (score >= 0) then
         num_completions = num_completions + 1
-        completions(num_completions) = '$' // trim(entries(i))
+        completions(num_completions) = '$' // entry(1:eqpos-1)
       end if
+      if (i > 100000) exit  ! safety bound
     end do
   end subroutine
 

--- a/src/parsing/grammar_parser.f90
+++ b/src/parsing/grammar_parser.f90
@@ -110,6 +110,15 @@ contains
       call advance(state)
       tok = current_token(state)
     end do
+    ! Anything left at the top level (e.g. a stray ')' or 'done') is a syntax
+    ! error — without this, the leading fragment ran and the rest was silently
+    ! dropped while the shell reported success (bash returns 2 here).
+    if (tok%token_type /= TOKEN_EOF .and. .not. state%has_error) then
+      call write_stderr('sh: -c: line 1: syntax error near unexpected token `' &
+                        // trim(tok%value) // "'")
+      state%has_error = .true.
+      state%error_msg = 'syntax error near unexpected token ' // trim(tok%value)
+    end if
   end function
 
   recursive function parse_list(state) result(node)

--- a/src/parsing/grammar_parser.f90
+++ b/src/parsing/grammar_parser.f90
@@ -300,6 +300,9 @@ contains
       case('{')
         node => parse_brace_group(state)
         is_compound = .true.
+      case('function')
+        ! ksh/bash `function name { ... }` (and `function name() { ... }`)
+        node => parse_function_stmt(state)
       case('coproc')
         node => parse_coproc_stmt(state)
         is_compound = .true.
@@ -326,6 +329,44 @@ contains
     ! (simple commands already handle redirections internally)
     if (is_compound .and. associated(node)) then
       call parse_trailing_redirections(state, node)
+    end if
+  end function
+
+  ! Parse the `function` keyword form: `function NAME [()] { ... }`
+  recursive function parse_function_stmt(state) result(node)
+    type(parser_state_t), intent(inout) :: state
+    type(command_node_t), pointer :: node, func_body
+    type(token_t) :: tok
+    character(len=MAX_TOKEN_LEN) :: func_name
+
+    node => null()
+    call advance(state)  ! consume 'function'
+
+    tok = current_token(state)
+    if (tok%token_type /= TOKEN_WORD) then
+      state%has_error = .true.
+      state%error_msg = 'expected name after "function"'
+      return
+    end if
+    func_name = tok%value
+    call advance(state)
+
+    ! Optional empty parentheses
+    tok = current_token(state)
+    if (tok%token_type == TOKEN_OPERATOR .and. trim(tok%value) == '(') then
+      call advance(state)
+      tok = current_token(state)
+      if (tok%token_type == TOKEN_OPERATOR .and. trim(tok%value) == ')') call advance(state)
+    end if
+
+    call skip_newlines(state)
+    tok = current_token(state)
+    if (tok%token_type == TOKEN_KEYWORD .and. trim(tok%value) == '{') then
+      func_body => parse_brace_group(state)
+      node => create_function_def(trim(func_name), func_body)
+    else
+      state%has_error = .true.
+      state%error_msg = 'expected "{" in function definition'
     end if
   end function
 

--- a/src/parsing/grammar_parser.f90
+++ b/src/parsing/grammar_parser.f90
@@ -27,7 +27,13 @@ module grammar_parser
     logical :: has_error = .false.
     character(len=:), allocatable :: error_msg
     character(len=:), allocatable :: raw_input  ! For heredoc extraction
+    integer :: depth = 0  ! compound-command nesting depth (recursion guard)
   end type parser_state_t
+
+  ! Cap on nested compound-command depth ({ }, ( ), if/while/for, ...).
+  ! Without this, deeply nested input recurses until the C stack overflows
+  ! and the process dumps core; past the cap we emit a syntax error instead.
+  integer, parameter :: MAX_PARSE_DEPTH = 200
 
 contains
 
@@ -274,6 +280,19 @@ contains
     type(command_node_t), pointer :: node
     type(token_t) :: tok, next_tok
     logical :: is_compound
+
+    ! Bound recursion so deeply nested compound commands can't overflow the
+    ! stack (they used to dump core). Depth is decremented at the single exit.
+    state%depth = state%depth + 1
+    if (state%depth > MAX_PARSE_DEPTH) then
+      state%has_error = .true.
+      if (.not. allocated(state%error_msg)) &
+        state%error_msg = 'maximum nesting depth exceeded'
+      node => null()
+      state%depth = state%depth - 1
+      return
+    end if
+
     tok = current_token(state)
     is_compound = .false.
     if (tok%token_type == TOKEN_KEYWORD) then
@@ -327,6 +346,8 @@ contains
     if (is_compound .and. associated(node)) then
       call parse_trailing_redirections(state, node)
     end if
+
+    state%depth = state%depth - 1
   end function
 
   function parse_simple_cmd(state) result(node)

--- a/src/parsing/grammar_parser.f90
+++ b/src/parsing/grammar_parser.f90
@@ -247,19 +247,32 @@ contains
     if (.not. associated(node)) return
     tok = current_token(state)
     if (tok%token_type == TOKEN_OPERATOR .and. trim(tok%value) == '|') then
-      allocate(commands(10))
+      allocate(commands(16))
       num_commands = 1
       commands(1) = node
       do while (tok%token_type == TOKEN_OPERATOR .and. trim(tok%value) == '|')
         call advance(state)
         call skip_newlines(state)
-        if (num_commands >= 10) exit
         temp_node => parse_command_node(state)
         if (.not. associated(temp_node)) then
           ! Incomplete pipeline - set error, print message, and exit
           call write_stderr('sh: -c: line 1: syntax error: unexpected end of file')
           state%has_error = .true.
           exit
+        end if
+        ! Grow the stage array instead of capping at a fixed count — long
+        ! pipelines (15-20 stages) used to stop here, leaving `| cmd` leftover.
+        if (num_commands >= size(commands)) then
+          block
+            type(command_node_t), pointer :: tmp(:)
+            integer :: gk
+            allocate(tmp(size(commands) * 2))
+            do gk = 1, num_commands
+              tmp(gk) = commands(gk)
+            end do
+            deallocate(commands)
+            commands => tmp
+          end block
         end if
         num_commands = num_commands + 1
         commands(num_commands) = temp_node

--- a/src/parsing/grammar_parser.f90
+++ b/src/parsing/grammar_parser.f90
@@ -27,13 +27,7 @@ module grammar_parser
     logical :: has_error = .false.
     character(len=:), allocatable :: error_msg
     character(len=:), allocatable :: raw_input  ! For heredoc extraction
-    integer :: depth = 0  ! compound-command nesting depth (recursion guard)
   end type parser_state_t
-
-  ! Cap on nested compound-command depth ({ }, ( ), if/while/for, ...).
-  ! Without this, deeply nested input recurses until the C stack overflows
-  ! and the process dumps core; past the cap we emit a syntax error instead.
-  integer, parameter :: MAX_PARSE_DEPTH = 200
 
 contains
 
@@ -280,19 +274,6 @@ contains
     type(command_node_t), pointer :: node
     type(token_t) :: tok, next_tok
     logical :: is_compound
-
-    ! Bound recursion so deeply nested compound commands can't overflow the
-    ! stack (they used to dump core). Depth is decremented at the single exit.
-    state%depth = state%depth + 1
-    if (state%depth > MAX_PARSE_DEPTH) then
-      state%has_error = .true.
-      if (.not. allocated(state%error_msg)) &
-        state%error_msg = 'maximum nesting depth exceeded'
-      node => null()
-      state%depth = state%depth - 1
-      return
-    end if
-
     tok = current_token(state)
     is_compound = .false.
     if (tok%token_type == TOKEN_KEYWORD) then
@@ -346,8 +327,6 @@ contains
     if (is_compound .and. associated(node)) then
       call parse_trailing_redirections(state, node)
     end if
-
-    state%depth = state%depth - 1
   end function
 
   function parse_simple_cmd(state) result(node)

--- a/src/parsing/grammar_parser.f90
+++ b/src/parsing/grammar_parser.f90
@@ -572,21 +572,21 @@ contains
         end if
         num_redirects = num_redirects + 1
 
-          ! Check if previous word was a file descriptor number (e.g., "2" before ">", "3" before "<&")
-          ! FD must be a single digit (0-9) to avoid false positives like "/tmp"
+          ! Check if previous word was a file descriptor number (e.g., "2" before ">", "10" before "<&")
           if (num_words > 0 .and. (trim(tok%value) == '>' .or. trim(tok%value) == '>&' .or. &
                                     trim(tok%value) == '<' .or. trim(tok%value) == '<&' .or. &
                                     trim(tok%value) == '>>' .or. trim(tok%value) == '<>')) then
-            ! Only treat as FD if it's exactly one digit character
-            if (len_trim(words(num_words)) == 1 .and. &
-                index('0123456789', trim(words(num_words))) > 0) then
+            ! Treat as an fd only if the word is all digits (1-3 of them), so
+            ! multi-digit fds like `exec 10>f` work; non-numeric words (/tmp) don't.
+            if (len_trim(words(num_words)) >= 1 .and. len_trim(words(num_words)) <= 3 .and. &
+                verify(trim(words(num_words)), '0123456789') == 0) then
               read(words(num_words), *, iostat=io_stat) fd_num
             else
-              ! Not a single digit, treat as regular word
+              ! Not numeric, treat as regular word
               io_stat = -1  ! Force failure
               fd_num = -1
             end if
-            if (io_stat == 0 .and. fd_num >= 0 .and. fd_num <= 9) then
+            if (io_stat == 0 .and. fd_num >= 0 .and. fd_num <= 255) then
               ! Previous word was a single digit - this is fd redirection
               select case(trim(tok%value))
               case('>&')

--- a/src/parsing/lexer.f90
+++ b/src/parsing/lexer.f90
@@ -815,20 +815,16 @@ contains
           end if
           pos = pos + 1  ! Skip the opening quote
         else if (ch == '#') then
-          ! # is normally comment, but in $# it's part of variable
-          ! Keep it if current token is just $
-          if (token_len == 1 .and. current_token(1:1) == '$') then
+          ! Inside a word, '#' is a literal character — bash only begins a
+          ! comment when '#' starts a word (after whitespace/operator/newline),
+          ! which is handled in the NORMAL state. So `echo a#b` -> a#b, and
+          ! `$#` stays the parameter. `echo a #b` still comments (the space
+          ! ends the word first, then '#' is seen in the NORMAL state).
+          if (token_len < MAX_TOKEN_LEN) then
             token_len = token_len + 1
             current_token(token_len:token_len) = ch
-            pos = pos + 1
-          else
-            ! End word, let # start a comment
-            call add_word_or_keyword(tokens, num_tokens, current_token(1:token_len), &
-                                    token_start, pos-1, token_has_quoted_part, in_escape)
-            state = LEX_NORMAL
-            in_escape = .false.
-            token_has_quoted_part = .false.
           end if
+          pos = pos + 1
         else if (ch == '$' .and. pos < input_len .and. next_ch == '(') then
           ! $( for command/arithmetic substitution - keep in word
           if (token_len < MAX_TOKEN_LEN - 1) then

--- a/src/parsing/parser.f90
+++ b/src/parsing/parser.f90
@@ -2334,26 +2334,38 @@ contains
         end if
       end if
     else
-      ! ~username expansion
+      ! ~username expansion — resolve the real home via getpwnam.
       start_pos = pos
       do while (pos <= len_trim(token) .and. token(pos:pos) /= '/' .and. token(pos:pos) /= ' ')
         pos = pos + 1
       end do
-      
+
       if (pos > start_pos) then
         username = token(start_pos:pos-1)
       else
         username = ''
       end if
-      
-      ! Simple implementation: assume user home is in /home/username
-      ! In a full implementation, you'd use getpwnam() system call
-      home_path = '/home/' // trim(username)
-      result(result_pos:result_pos+len_trim(home_path)-1) = trim(home_path)
-      result_pos = result_pos + len_trim(home_path)
-      
-      ! Don't increment pos here as it's already at the next character
-      pos = pos - 1  ! Adjust because main loop will increment
+
+      block
+        character(len=:), allocatable :: user_home
+        user_home = get_user_home(trim(username))
+        if (len(user_home) > 0) then
+          result(result_pos:result_pos+len(user_home)-1) = user_home
+          result_pos = result_pos + len(user_home)
+        else
+          ! Unknown user: leave "~username" literal (matches bash).
+          result(result_pos:result_pos) = '~'
+          result_pos = result_pos + 1
+          if (len_trim(username) > 0) then
+            result(result_pos:result_pos+len_trim(username)-1) = trim(username)
+            result_pos = result_pos + len_trim(username)
+          end if
+        end if
+      end block
+
+      ! pos already points at the terminator ('/'/space) or just past the end,
+      ! exactly like the bare-~ branch above — do NOT step back (that re-copied
+      ! the username's last char, e.g. ~root -> /home/roott).
     end if
   end subroutine
 

--- a/src/scripting/advanced_test.f90
+++ b/src/scripting/advanced_test.f90
@@ -508,27 +508,22 @@ contains
   function files_same_device_inode(file1, file2) result(same)
     character(len=*), intent(in) :: file1, file2
     logical :: same
-    
-    ! Simplified: compare paths
-    same = (trim(file1) == trim(file2))
+    ! -ef: same device + inode (native stat, not a path string compare)
+    same = file_same_as(file1, file2)
   end function
 
   function file_newer_than(file1, file2) result(newer)
     character(len=*), intent(in) :: file1, file2
     logical :: newer
-
-    ! Placeholder implementation
-    newer = .false.
-    if (.false.) print *, file1, file2  ! Silence unused warnings
+    ! -nt: file1 mtime > file2 mtime (native stat)
+    newer = file_is_newer(file1, file2)
   end function
 
   function file_older_than(file1, file2) result(older)
     character(len=*), intent(in) :: file1, file2
     logical :: older
-
-    ! Placeholder implementation
-    older = .false.
-    if (.false.) print *, file1, file2  ! Silence unused warnings
+    ! -ot: file1 mtime < file2 mtime (native stat)
+    older = file_is_older(file1, file2)
   end function
 
   function file_size(filename) result(size)
@@ -551,80 +546,51 @@ contains
     end if
   end function
 
-  ! File type checking (simplified implementations)
+  ! File type checks — delegate to the native stat-based helpers in
+  ! system_interface (these used to be hardcoded always-false placeholders).
   function is_symbolic_link(filename) result(is_link)
     character(len=*), intent(in) :: filename
     logical :: is_link
-
-    is_link = .false.  ! Placeholder
-    if (.false.) print *, filename  ! Silence unused warning
+    is_link = file_is_symlink(filename)
   end function
 
   function is_block_device(filename) result(is_block)
     character(len=*), intent(in) :: filename
     logical :: is_block
-
-    is_block = .false.  ! Placeholder
-    if (.false.) print *, filename  ! Silence unused warning
+    is_block = file_is_block_device(filename)
   end function
 
   function is_char_device(filename) result(is_char)
     character(len=*), intent(in) :: filename
     logical :: is_char
-
-    is_char = .false.  ! Placeholder
-    if (.false.) print *, filename  ! Silence unused warning
+    is_char = file_is_char_device(filename)
   end function
 
   function is_named_pipe(filename) result(is_pipe)
     character(len=*), intent(in) :: filename
     logical :: is_pipe
-
-    is_pipe = .false.  ! Placeholder
-    if (.false.) print *, filename  ! Silence unused warning
+    is_pipe = file_is_fifo(filename)
   end function
 
   function is_socket(filename) result(is_sock)
     character(len=*), intent(in) :: filename
     logical :: is_sock
-
-    is_sock = .false.  ! Placeholder
-    if (.false.) print *, filename  ! Silence unused warning
+    is_sock = file_is_socket(filename)
   end function
 
   subroutine get_file_info(filename, exists, is_file, is_dir, is_executable, is_readable, is_writable)
     character(len=*), intent(in) :: filename
     logical, intent(out) :: exists, is_file, is_dir, is_executable, is_readable, is_writable
-    
-    character(len=:), allocatable :: test_cmd
-    integer :: status
-    
-    ! Use system test command for file properties
+
+    ! Native stat/access — previously this forked five `test` subprocesses
+    ! per file check.
     inquire(file=trim(filename), exist=exists)
-    
     if (exists) then
-      ! Test if it's a regular file
-      test_cmd = 'test -f ' // trim(filename)
-      call execute_command_line(test_cmd, exitstat=status)
-      is_file = (status == 0)
-      
-      ! Test if it's a directory
-      test_cmd = 'test -d ' // trim(filename)
-      call execute_command_line(test_cmd, exitstat=status)
-      is_dir = (status == 0)
-      
-      ! Test permissions
-      test_cmd = 'test -r ' // trim(filename)
-      call execute_command_line(test_cmd, exitstat=status)
-      is_readable = (status == 0)
-      
-      test_cmd = 'test -w ' // trim(filename)
-      call execute_command_line(test_cmd, exitstat=status)
-      is_writable = (status == 0)
-      
-      test_cmd = 'test -x ' // trim(filename)
-      call execute_command_line(test_cmd, exitstat=status)
-      is_executable = (status == 0)
+      is_file       = file_is_regular(filename)
+      is_dir        = file_is_directory(filename)
+      is_readable   = file_is_readable(filename)
+      is_writable   = file_is_writable(filename)
+      is_executable = file_is_executable(filename)
     else
       is_file = .false.
       is_dir = .false.

--- a/src/scripting/expansion.f90
+++ b/src/scripting/expansion.f90
@@ -171,23 +171,19 @@ contains
           if (is_keys_expansion .and. is_all_expansion) then
             ! ${!array[@]} - return all keys
             block
-              character(len=4096) :: kbuf
-              integer :: kpos, klen
-              kbuf = ''; kpos = 1
+              character(len=:), allocatable :: kbuf
+              integer :: klen
+              kbuf = ''
               allocate(keys(500))
               call get_assoc_array_keys(shell, trim(array_name), keys, num_keys)
               do j = 1, min(num_keys, 500)
                 klen = len_trim(keys(j))
                 if (klen == 0) cycle
-                if (kpos > 1) then; kbuf(kpos:kpos) = ' '; kpos = kpos + 1; end if
-                kbuf(kpos:kpos+klen-1) = keys(j)(1:klen)
-                kpos = kpos + klen
+                ! allocatable accumulator — never a fixed buffer (overflow guard)
+                if (len(kbuf) > 0) kbuf = kbuf // ' '
+                kbuf = kbuf // keys(j)(1:klen)
               end do
-              if (kpos > 1) then
-                result_value = kbuf(1:kpos-1)
-              else
-                result_value = ''
-              end if
+              result_value = kbuf
             end block
             deallocate(keys)
             return
@@ -202,22 +198,19 @@ contains
           else if (is_all_expansion) then
             ! ${array[@]} - return all values
             block
-              character(len=4096) :: vbuf
-              integer :: vpos, vlen
-              vbuf = ''; vpos = 1
+              character(len=:), allocatable :: vbuf
+              integer :: vlen
+              vbuf = ''
               allocate(keys(500))
               call get_assoc_array_keys(shell, trim(array_name), keys, num_keys)
               do j = 1, min(num_keys, 500)
                 var_value = get_assoc_array_value(shell, trim(array_name), trim(keys(j)))
                 vlen = len_trim(var_value)
-                if (vpos > 1) then; vbuf(vpos:vpos) = ' '; vpos = vpos + 1; end if
-                if (vlen > 0) then; vbuf(vpos:vpos+vlen-1) = var_value(1:vlen); vpos = vpos + vlen; end if
+                ! allocatable accumulator — never a fixed buffer (overflow guard)
+                if (len(vbuf) > 0) vbuf = vbuf // ' '
+                if (vlen > 0) vbuf = vbuf // var_value(1:vlen)
               end do
-              if (vpos > 1) then
-                result_value = vbuf(1:vpos-1)
-              else
-                result_value = ''
-              end if
+              result_value = vbuf
             end block
             deallocate(keys)
             return
@@ -239,32 +232,28 @@ contains
             if (is_keys_expansion) then
               ! ${!arr[@]} — list indices of set elements (sparse-aware)
               block
-                integer :: ki, arr_sz, kpos
-                character(len=4096) :: kbuf
+                integer :: ki, arr_sz
+                character(len=:), allocatable :: kbuf
                 character(len=:), allocatable :: elem
-                kbuf = ''; kpos = 1
+                kbuf = ''
                 arr_sz = get_array_size(shell, trim(array_name))
                 do ki = 1, arr_sz
                   elem = get_array_element(shell, trim(array_name), ki)
                   if (len_trim(elem) > 0) then
-                    if (kpos > 1) then; kbuf(kpos:kpos) = ' '; kpos = kpos + 1; end if
+                    ! allocatable accumulator — never a fixed buffer (overflow guard)
+                    if (len(kbuf) > 0) kbuf = kbuf // ' '
                     write(num_buf, '(I0)') ki - 1  ! 0-based index
-                    kbuf(kpos:kpos+len_trim(num_buf)-1) = trim(num_buf)
-                    kpos = kpos + len_trim(num_buf)
+                    kbuf = kbuf // trim(num_buf)
                   end if
                 end do
-                if (kpos > 1) then
-                  result_value = kbuf(1:kpos-1)
-                else
-                  result_value = ''
-                end if
+                result_value = kbuf
               end block
               return
             else if (is_length_expansion) then
               ! ${#arr[@]} — count of elements
               block
                 integer :: ki, arr_count
-                character(len=4096) :: all_str
+                character(len=:), allocatable :: all_str
                 all_str = trim(get_array_all_elements(shell, trim(array_name)))
                 arr_count = 0
                 if (len_trim(all_str) > 0) then
@@ -280,7 +269,7 @@ contains
             else
               ! ${arr[@]} — all values, with optional slicing
               block
-                character(len=4096) :: all_str
+                character(len=:), allocatable :: all_str
                 character(len=256) :: slice_spec
                 integer :: colon_after, sc_pos2, ios1, ios2
                 integer :: s_offset, s_length, w_count, w_start, w_idx, w_out

--- a/src/scripting/expansion.f90
+++ b/src/scripting/expansion.f90
@@ -3836,7 +3836,12 @@ contains
       end if
 
       if (is_numeric) then
-        ! Numeric range expansion — O(n) with pre-allocated buffer
+        ! Numeric range expansion — O(n) with pre-allocated buffer.
+        ! The step is a magnitude; direction comes from start vs end (bash
+        ! semantics). A zero/negative step would otherwise make num_values
+        ! negative and the buffer allocation negative-sized -> crash.
+        step_val = abs(step_val)
+        if (step_val == 0) step_val = 1
         if (start_val <= end_val) then
           num_values = (end_val - start_val) / step_val + 1
         else

--- a/src/scripting/printf_builtin.f90
+++ b/src/scripting/printf_builtin.f90
@@ -7,6 +7,10 @@ module printf_builtin
   use iso_fortran_env, only: output_unit, error_unit
   implicit none
 
+  ! Upper bound on printf field width/precision. A larger value (literal or via
+  ! '*') would drive an unbounded buffer allocation and abort the shell.
+  integer, parameter :: MAX_PRINTF_FIELD = 1000000
+
   ! Format specifier components
   type :: format_info_t
     logical :: left_align = .false.     ! '-' flag
@@ -165,6 +169,8 @@ contains
               read(args(arg_index), *, err=10, end=10) fmt_info%width
 10            arg_index = arg_index + 1
             end if
+            if (fmt_info%width > MAX_PRINTF_FIELD) fmt_info%width = MAX_PRINTF_FIELD
+            if (fmt_info%width < -MAX_PRINTF_FIELD) fmt_info%width = -MAX_PRINTF_FIELD
           end if
 
           ! Handle dynamic precision from argument
@@ -173,6 +179,8 @@ contains
               read(args(arg_index), *, err=20, end=20) fmt_info%precision
 20            arg_index = arg_index + 1
             end if
+            if (fmt_info%precision > MAX_PRINTF_FIELD) fmt_info%precision = MAX_PRINTF_FIELD
+            if (fmt_info%precision < 0) fmt_info%precision = 0
           end if
 
           ! Get argument value and its length
@@ -222,6 +230,8 @@ contains
     integer :: format_len, width_start
     character :: c
     logical :: parsing_flags, parsing_width, parsing_precision
+    integer(kind=8) :: fld8  ! read width/precision wide first, then clamp
+    integer :: rd_ios
 
     ! Initialize
     fmt_info%left_align = .false.
@@ -288,7 +298,13 @@ contains
           if (c < '0' .or. c > '9') exit
           pos = pos + 1
         end do
-        read(format_str(width_start:pos-1), '(I10)') fmt_info%width
+        ! Read wide (a huge literal like %9999999999d overflows a 32-bit read
+        ! and aborts the shell), then clamp — a large width would otherwise
+        ! drive an unbounded buffer allocation.
+        read(format_str(width_start:pos-1), *, iostat=rd_ios) fld8
+        if (rd_ios /= 0) fld8 = MAX_PRINTF_FIELD
+        fld8 = max(-int(MAX_PRINTF_FIELD, 8), min(int(MAX_PRINTF_FIELD, 8), fld8))
+        fmt_info%width = int(fld8)
         c = format_str(pos:pos)
       end if
 
@@ -308,7 +324,10 @@ contains
             if (c < '0' .or. c > '9') exit
             pos = pos + 1
           end do
-          read(format_str(width_start:pos-1), '(I10)') fmt_info%precision
+          read(format_str(width_start:pos-1), *, iostat=rd_ios) fld8
+          if (rd_ios /= 0) fld8 = MAX_PRINTF_FIELD
+          fld8 = max(0_8, min(int(MAX_PRINTF_FIELD, 8), fld8))
+          fmt_info%precision = int(fld8)
         else
           fmt_info%precision = 0
         end if

--- a/src/scripting/shell_options.f90
+++ b/src/scripting/shell_options.f90
@@ -70,11 +70,12 @@ contains
       if (option_str == '--') then
         setting_positional = .true.
         i = i + 1
-        ! Clear existing positional parameters
+        ! Clear and resize positional parameters to hold all args (no 50 cap)
         shell%num_positional = 0
-        ! Set remaining arguments as positional parameters
+        if (allocated(shell%positional_params)) deallocate(shell%positional_params)
+        allocate(shell%positional_params(max(1, cmd%num_tokens - i + 1)))
         param_idx = 1
-        do while (i <= cmd%num_tokens .and. param_idx <= 50)
+        do while (i <= cmd%num_tokens)
           shell%positional_params(param_idx)%str = trim(cmd%tokens(i))
           write(param_idx_str, '(I0)') param_idx
           call set_shell_variable(shell, trim(param_idx_str), trim(cmd%tokens(i)))
@@ -91,8 +92,10 @@ contains
       if (arg_len >= 1 .and. option_str(1:1) /= '-' .and. option_str(1:1) /= '+') then
         setting_positional = .true.
         shell%num_positional = 0
+        if (allocated(shell%positional_params)) deallocate(shell%positional_params)
+        allocate(shell%positional_params(max(1, cmd%num_tokens - i + 1)))
         param_idx = 1
-        do while (i <= cmd%num_tokens .and. param_idx <= 50)
+        do while (i <= cmd%num_tokens)
           shell%positional_params(param_idx)%str = trim(cmd%tokens(i))
           write(param_idx_str, '(I0)') param_idx
           call set_shell_variable(shell, trim(param_idx_str), trim(cmd%tokens(i)))

--- a/src/scripting/variables.f90
+++ b/src/scripting/variables.f90
@@ -1235,12 +1235,11 @@ contains
   function get_array_all_elements(shell, name) result(result_str)
     type(shell_state_t), intent(in) :: shell
     character(len=*), intent(in) :: name
-    character(len=4096) :: result_str
-    integer :: i, j, pos
+    character(len=:), allocatable :: result_str
+    integer :: i, j
     logical :: first
 
     result_str = ''
-    pos = 1
     first = .true.
 
     do i = 1, shell%num_variables
@@ -1248,14 +1247,11 @@ contains
         do j = 1, shell%variables(i)%array_size
           if (.not. allocated(shell%variables(i)%array_values(j)%str)) cycle
           if (len_trim(shell%variables(i)%array_values(j)%str) == 0) cycle
-          if (.not. first) then
-            result_str(pos:pos) = ' '
-            pos = pos + 1
-          end if
+          ! Grow an allocatable accumulator — never a fixed buffer (a large
+          ! array used to overflow a 4096-byte result_str and SIGSEGV).
+          if (.not. first) result_str = result_str // ' '
           first = .false.
-          result_str(pos:pos+len_trim(shell%variables(i)%array_values(j)%str)-1) = &
-            trim(shell%variables(i)%array_values(j)%str)
-          pos = pos + len_trim(shell%variables(i)%array_values(j)%str)
+          result_str = result_str // trim(shell%variables(i)%array_values(j)%str)
         end do
         return
       end if

--- a/src/system/interface.f90
+++ b/src/system/interface.f90
@@ -384,6 +384,12 @@ module system_interface
       integer(c_int) :: c_setenv
     end function
 
+    function c_strlen(s) bind(C, name="strlen")
+      import :: c_ptr, c_size_t
+      type(c_ptr), value :: s
+      integer(c_size_t) :: c_strlen
+    end function
+
     function c_unsetenv(name) bind(C, name="unsetenv")
       import :: c_ptr, c_int
       type(c_ptr), value :: name
@@ -786,23 +792,23 @@ contains
     character(len=:), allocatable :: value
     type(c_ptr) :: c_value_ptr
     character(kind=c_char), pointer :: c_value(:)
-    integer :: i
+    integer :: i, vlen
     character(len=256), target :: c_var_name
-    
+
     c_var_name = trim(var_name)//c_null_char
     c_value_ptr = c_getenv(c_loc(c_var_name))
-    
+
     if (c_associated(c_value_ptr)) then
-      call c_f_pointer(c_value_ptr, c_value, [MAX_ENV_LEN])
-      
-      do i = 1, MAX_ENV_LEN
-        if (c_value(i) == c_null_char) exit
-      end do
-      
-      allocate(character(len=i-1) :: value)
-      do i = 1, len(value)
-        value(i:i) = c_value(i)
-      end do
+      ! Map the exact C-string length (strlen) — a fixed MAX_ENV_LEN window
+      ! both capped long values and over-claimed the pointer extent.
+      vlen = int(c_strlen(c_value_ptr))
+      allocate(character(len=vlen) :: value)
+      if (vlen > 0) then
+        call c_f_pointer(c_value_ptr, c_value, [vlen])
+        do i = 1, vlen
+          value(i:i) = c_value(i)
+        end do
+      end if
     else
       allocate(character(len=0) :: value)
     end if
@@ -811,12 +817,23 @@ contains
   function set_environment_var(var_name, var_value) result(success)
     character(len=*), intent(in) :: var_name, var_value
     logical :: success
-    integer :: ret
-    character(len=MAX_TOKEN_LEN), target :: c_var_name
-    character(len=MAX_PATH_LEN), target :: c_var_value
+    integer :: ret, i, nlen, vlen
+    ! Allocatable c_char targets sized to the actual strings — fixed buffers
+    ! truncated long exported values (e.g. a big PATH) at 4096 bytes.
+    character(kind=c_char), dimension(:), allocatable, target :: c_var_name, c_var_value
 
-    c_var_name = trim(var_name)//c_null_char
-    c_var_value = trim(var_value)//c_null_char
+    nlen = len_trim(var_name)
+    vlen = len_trim(var_value)
+    allocate(c_var_name(nlen + 1), c_var_value(vlen + 1))
+    do i = 1, nlen
+      c_var_name(i) = var_name(i:i)
+    end do
+    c_var_name(nlen + 1) = c_null_char
+    do i = 1, vlen
+      c_var_value(i) = var_value(i:i)
+    end do
+    c_var_value(vlen + 1) = c_null_char
+
     ret = c_setenv(c_loc(c_var_name), c_loc(c_var_value), 1_c_int)
     success = (ret == 0)
   end function

--- a/src/system/interface.f90
+++ b/src/system/interface.f90
@@ -390,6 +390,12 @@ module system_interface
       integer(c_size_t) :: c_strlen
     end function
 
+    function c_user_home(name) bind(C, name="fortsh_user_home")
+      import :: c_ptr, c_char
+      character(kind=c_char), intent(in) :: name(*)
+      type(c_ptr) :: c_user_home
+    end function
+
     function c_unsetenv(name) bind(C, name="unsetenv")
       import :: c_ptr, c_int
       type(c_ptr), value :: name
@@ -811,6 +817,39 @@ contains
       end if
     else
       allocate(character(len=0) :: value)
+    end if
+  end function
+
+  ! Home directory for a named user via getpwnam (for ~user expansion).
+  ! Returns '' if the user does not exist (caller leaves ~user literal).
+  function get_user_home(username) result(home)
+    character(len=*), intent(in) :: username
+    character(len=:), allocatable :: home
+    type(c_ptr) :: p
+    character(kind=c_char), pointer :: cs(:)
+    character(kind=c_char), dimension(:), allocatable, target :: cname
+    integer :: i, n
+
+    home = ''
+    n = len_trim(username)
+    if (n == 0) return
+    allocate(cname(n + 1))
+    do i = 1, n
+      cname(i) = username(i:i)
+    end do
+    cname(n + 1) = c_null_char
+
+    p = c_user_home(cname)
+    if (c_associated(p)) then
+      n = int(c_strlen(p))
+      if (allocated(home)) deallocate(home)
+      allocate(character(len=n) :: home)
+      if (n > 0) then
+        call c_f_pointer(p, cs, [n])
+        do i = 1, n
+          home(i:i) = cs(i)
+        end do
+      end if
     end if
   end function
 

--- a/src/system/interface.f90
+++ b/src/system/interface.f90
@@ -396,6 +396,14 @@ module system_interface
       type(c_ptr) :: c_user_home
     end function
 
+    ! Native terminal size via ioctl done in C (src/c_interop/terminal_size.c),
+    ! which avoids the flang-new crash on the Fortran c_loc(winsize) path.
+    function c_get_term_size(rows, cols) bind(C, name="get_term_size_c")
+      import :: c_int
+      integer(c_int), intent(out) :: rows, cols
+      integer(c_int) :: c_get_term_size
+    end function
+
     function c_unsetenv(name) bind(C, name="unsetenv")
       import :: c_ptr, c_int
       type(c_ptr), value :: name
@@ -818,6 +826,18 @@ contains
     else
       allocate(character(len=0) :: value)
     end if
+  end function
+
+  ! Terminal size via the C ioctl helper (no `tput` subprocess; safe on flang).
+  function get_term_size_native(rows, cols) result(ok)
+    integer, intent(out) :: rows, cols
+    logical :: ok
+    integer(c_int) :: r, c, ret
+    r = 24; c = 80
+    ret = c_get_term_size(r, c)
+    rows = int(r)
+    cols = int(c)
+    ok = (ret == 0)
   end function
 
   ! Home directory for a named user via getpwnam (for ~user expansion).

--- a/src/system/interface.f90
+++ b/src/system/interface.f90
@@ -969,65 +969,56 @@ contains
     character(len=:), allocatable :: output
 
     type(c_ptr) :: pipe_ptr
-    character(kind=c_char), target :: buffer(4096)  ! Larger buffer per read
-    character(len=65536) :: temp_output  ! 64KB buffer
+    character(kind=c_char), target :: buffer(4096)  ! one fgets chunk
+    character(len=4096) :: chunk                     ! collapsed chunk (<= one read)
     type(c_ptr) :: ret_ptr
-    integer :: i, pos, bytes_read
-    character(len=256), target :: c_command
+    integer :: i, clen, cmdlen
+    ! Allocatable command/output — fixed buffers truncated the command at 256B
+    ! and the output at 64KB.
+    character(kind=c_char), dimension(:), allocatable, target :: c_command
     character(len=4), target :: c_mode
 
-    ! Convert strings to proper format
-    c_command = trim(command)//c_null_char
+    output = ''
+
+    cmdlen = len_trim(command)
+    allocate(c_command(cmdlen + 1))
+    do i = 1, cmdlen
+      c_command(i) = command(i:i)
+    end do
+    c_command(cmdlen + 1) = c_null_char
     c_mode = 'r'//c_null_char
 
-    ! Open pipe to command
     pipe_ptr = c_popen(c_loc(c_command), c_loc(c_mode))
+    if (.not. c_associated(pipe_ptr)) return
 
-    if (.not. c_associated(pipe_ptr)) then
-      allocate(character(len=0) :: output)
-      return
-    end if
-
-    temp_output = ''
-    pos = 1
-
-    ! Read output with larger buffer
+    ! Read the whole output, collapsing runs of newlines to single spaces,
+    ! growing an allocatable accumulator (append per chunk, not per char).
     do
-      ! Initialize buffer for this read
       buffer = c_null_char
-
       ret_ptr = c_fgets(c_loc(buffer), int(4096, c_int), pipe_ptr)
       if (.not. c_associated(ret_ptr)) exit
 
-      ! Convert to Fortran string
-      bytes_read = 0
+      clen = 0
       do i = 1, 4096
         if (buffer(i) == c_null_char) exit
-        bytes_read = bytes_read + 1
-        if (pos > len(temp_output)) exit  ! Buffer full
-
-        if (buffer(i) /= char(10)) then  ! Skip newlines
-          temp_output(pos:pos) = buffer(i)
-          pos = pos + 1
-        else if (pos > 1 .and. temp_output(pos-1:pos-1) /= ' ') then
-          temp_output(pos:pos) = ' '
-          pos = pos + 1
+        if (buffer(i) /= char(10)) then
+          clen = clen + 1
+          chunk(clen:clen) = buffer(i)
+        else
+          ! newline -> single space, unless the previous kept char is a space
+          if (clen > 0) then
+            if (chunk(clen:clen) /= ' ') then
+              clen = clen + 1; chunk(clen:clen) = ' '
+            end if
+          else if (len(output) > 0) then
+            if (output(len(output):len(output)) /= ' ') output = output // ' '
+          end if
         end if
       end do
-
-      ! Debug: Check if we should continue reading
-      ! Exit if we read less than expected OR hit buffer limit
-      if (pos > len(temp_output)) exit
-      if (bytes_read == 0) exit
+      if (clen > 0) output = output // chunk(1:clen)
     end do
 
-    ! Close pipe
     i = c_pclose(pipe_ptr)
-
-    ! Return output (deallocate first if already allocated, which shouldn't happen but prevents crash)
-    if (allocated(output)) deallocate(output)
-    allocate(character(len=pos-1) :: output)
-    output = temp_output(:pos-1)
   end function
 
   ! Like execute_and_capture but converts newlines to tabs instead of spaces.
@@ -1038,56 +1029,53 @@ contains
 
     type(c_ptr) :: pipe_ptr
     character(kind=c_char), target :: buffer(4096)
-    character(len=65536) :: temp_output
+    character(len=4096) :: chunk
     type(c_ptr) :: ret_ptr
-    integer :: i, pos, bytes_read
-    character(len=256), target :: c_command
+    integer :: i, clen, cmdlen
+    ! Allocatable command/output — fixed buffers capped command at 256B / output at 64KB
+    character(kind=c_char), dimension(:), allocatable, target :: c_command
     character(len=4), target :: c_mode
 
-    c_command = trim(command)//c_null_char
+    output = ''
+
+    cmdlen = len_trim(command)
+    allocate(c_command(cmdlen + 1))
+    do i = 1, cmdlen
+      c_command(i) = command(i:i)
+    end do
+    c_command(cmdlen + 1) = c_null_char
     c_mode = 'r'//c_null_char
 
     pipe_ptr = c_popen(c_loc(c_command), c_loc(c_mode))
-    if (.not. c_associated(pipe_ptr)) then
-      allocate(character(len=0) :: output)
-      return
-    end if
+    if (.not. c_associated(pipe_ptr)) return
 
-    temp_output = ''
-    pos = 1
-
+    ! Collapse runs of newlines to single tabs (preserves spaces in filenames),
+    ! growing an allocatable accumulator.
     do
       buffer = c_null_char
       ret_ptr = c_fgets(c_loc(buffer), int(4096, c_int), pipe_ptr)
       if (.not. c_associated(ret_ptr)) exit
 
-      bytes_read = 0
+      clen = 0
       do i = 1, 4096
         if (buffer(i) == c_null_char) exit
-        bytes_read = bytes_read + 1
-        if (pos > len(temp_output)) exit
-
         if (buffer(i) == char(10)) then
-          ! Convert newline to tab (preserves spaces in filenames)
-          if (pos > 1 .and. temp_output(pos-1:pos-1) /= char(9)) then
-            temp_output(pos:pos) = char(9)
-            pos = pos + 1
+          if (clen > 0) then
+            if (chunk(clen:clen) /= char(9)) then
+              clen = clen + 1; chunk(clen:clen) = char(9)
+            end if
+          else if (len(output) > 0) then
+            if (output(len(output):len(output)) /= char(9)) output = output // char(9)
           end if
         else
-          temp_output(pos:pos) = buffer(i)
-          pos = pos + 1
+          clen = clen + 1
+          chunk(clen:clen) = buffer(i)
         end if
       end do
-
-      if (pos > len(temp_output)) exit
-      if (bytes_read == 0) exit
+      if (clen > 0) output = output // chunk(1:clen)
     end do
 
     i = c_pclose(pipe_ptr)
-
-    if (allocated(output)) deallocate(output)
-    allocate(character(len=pos-1) :: output)
-    output = temp_output(:pos-1)
   end function
 
   ! Terminal control functions

--- a/src/system/interface.f90
+++ b/src/system/interface.f90
@@ -828,6 +828,66 @@ contains
     end if
   end function
 
+  ! True if `name` is an executable found on $PATH (native access(X_OK) scan;
+  ! no `which` subprocess). Bare names only — a name with '/' is checked as-is.
+  function command_in_path(name) result(found)
+    character(len=*), intent(in) :: name
+    logical :: found
+    character(len=:), allocatable :: path_var, cand
+    character(kind=c_char), dimension(:), allocatable, target :: cpath
+    integer :: spos, cpos, epos, i, clen
+
+    found = .false.
+    if (len_trim(name) == 0) return
+
+    if (index(trim(name), '/') > 0) then
+      cand = trim(name)
+    else
+      path_var = get_environment_var('PATH')
+      if (len(path_var) == 0) path_var = '/usr/bin:/bin'
+      cand = ''
+    end if
+
+    spos = 1
+    do
+      if (index(trim(name), '/') > 0) then
+        ! absolute/relative path: single candidate
+        if (len(cand) == 0) exit
+      else
+        if (spos > len(path_var)) exit
+        cpos = index(path_var(spos:), ':')
+        if (cpos == 0) then
+          epos = len(path_var)
+        else
+          epos = spos + cpos - 2
+        end if
+        if (epos >= spos) then
+          cand = path_var(spos:epos)
+        else
+          cand = '.'
+        end if
+        if (len_trim(cand) == 0) cand = '.'
+        cand = trim(cand) // '/' // trim(name)
+      end if
+
+      clen = len(cand)
+      if (allocated(cpath)) deallocate(cpath)
+      allocate(cpath(clen + 1))
+      do i = 1, clen
+        cpath(i) = cand(i:i)
+      end do
+      cpath(clen + 1) = c_null_char
+      if (c_access(c_loc(cpath), X_OK) == 0) then
+        found = .true.
+        return
+      end if
+
+      if (index(trim(name), '/') > 0) exit
+      if (cpos == 0) exit
+      spos = spos + cpos
+    end do
+  end function command_in_path
+
   ! Terminal size via the C ioctl helper (no `tput` subprocess; safe on flang).
   function get_term_size_native(rows, cols) result(ok)
     integer, intent(out) :: rows, cols


### PR DESCRIPTION
Addresses 20 findings from the multi-agent audit (`.docs/audits/`), grouped below. Every fix verified against `/bin/bash` and behind a clean local suite: **POSIX 144/0, integration 479/0, bench all passed** (re-run after each commit).

## Crashes (SIGSEGV/abort → fixed)
- **`${arr[@]}`/`${a[*]}`/`${#a[@]}` + assoc arrays** overflowed a fixed 4096B buffer → SIGSEGV. Now allocatable accumulators.
- **`{1..3..-1}` / `{1..5..0}`** negative/zero brace step → SIGSEGV/SIGFPE. Step treated as magnitude (bash semantics).
- **>4096-byte command name** → Fortran "End of record" abort in PATH lookup. Allocatable candidate + length guard.
- **printf `%9999999999d`** → unbounded-alloc abort. int64 read + clamp.

## Fixed-buffer caps removed (silent truncation → unbounded)
- **`eval`** command (was 4096B), **exported var** value read+write (was 4096B; child now sees full value), **`execute_and_capture[_tabs]`** (256B command / 64KB output).
- Surfaced & fixed a latent **10-stage pipeline cap** (long pipelines were silently truncated).

## Correctness / canonical (now matches bash)
- **Syntax errors return exit 2** (was 0); stray `)`/`done` no longer silently dropped.
- **`~user`** via `getpwnam` (+ literal on unknown user; fixed `~root`→`/home/roott` duplication).
- **Mid-word `#`** is literal (`echo a#b` → `a#b`).
- **`function name { }`** keyword form (and `function name()`), previously unrecognized.
- **`set --`** no longer caps positional params at 50.
- **Multi-digit redirection fds** (`exec 10>`).

## Bespoke de-shell-out (no subprocess for internal features)
- **`[[ ]]` / `test` / `[ ]` file tests** now native via `stat`/`access` — dropped the per-check `/bin/test` forks **and** fixed the always-false placeholders (`-L -h -p -b -c -S -nt -ot -ef`).
- **`$VAR` completion** reads the environment natively (was `env | cut | tr`).
- **Clipboard tool detection** via native `$PATH` scan (was `which`).
- **macOS terminal size** via the native ioctl C helper (was `tput`).
- **`fc`** re-executes history in the current shell via the AST evaluator (was `/bin/sh -c`) — functions/aliases/locals now visible, real exit code (not `256×code`).
- Removed dead `system()`/placeholder routines (`execute_external_command`, `builtin_timeout`, `check_system_resources`, `execute_exit_trap_inline`).

## Notes
- New C interop: `getpwnam` helper (`fd_wrapper.c`), bound `get_term_size_c`; new `system_interface` wrappers `get_user_home`, `get_term_size_native`, `command_in_path`, `strlen` binding.
- Audit reports live under `.docs/audits/` (gitignored).
- **Deferred to follow-up PRs** (need native fork/exec of an AST or platform-specific code, or focused debugging): process substitution `<()`/`>()` and `coproc` (still `/bin/sh -c`), native process list for Ctrl-X; the deep-`{ }`-nesting parse-time crash; array corruption past ~256 elements; `MAX_TOKENS` growable; fd-adjacency; perf (prompt-git cache, display diffing); security (temp-file hardening, ANSI sanitization). Tracked in the audit reports.

Built & tested on FreeBSD (gfortran). macOS-only paths (terminal size) validated by CI.