### PR TITLE
Audit fixes (security batch): temp-file hardening + ANSI-injection guards

### DIFF
--- a/src/c_interop/fd_wrapper.c
+++ b/src/c_interop/fd_wrapper.c
@@ -2,6 +2,8 @@
 #include <unistd.h>
 #include <errno.h>
 #include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <pwd.h>
@@ -11,6 +13,25 @@
 const char *fortsh_user_home(const char *name) {
     struct passwd *pw = getpwnam(name);
     return pw ? pw->pw_dir : (const char *)0;
+}
+
+// Securely create a temp file in $TMPDIR (or /tmp): builds "<dir>/<prefix>XXXXXX"
+// and mkstemp()s it (O_CREAT|O_EXCL, mode 0600, never follows a symlink, no
+// predictable name / race). Writes the chosen path to `out` and returns 0 on
+// success, -1 on failure. The unpredictable name makes a later open-by-name safe.
+int fortsh_make_temp(const char *prefix, char *out, int outlen) {
+    char tmpl[1024];
+    const char *dir = getenv("TMPDIR");
+    if (!dir || !*dir) dir = "/tmp";
+    if (snprintf(tmpl, sizeof(tmpl), "%s/%sXXXXXX", dir, prefix) >= (int)sizeof(tmpl))
+        return -1;
+    int fd = mkstemp(tmpl);
+    if (fd < 0) return -1;
+    close(fd);
+    if (outlen <= 0) return -1;
+    strncpy(out, tmpl, (size_t)(outlen - 1));
+    out[outlen - 1] = '\0';
+    return 0;
 }
 
 // macOS kernel bug workaround: set S_CTTYREF on the controlling terminal.

--- a/src/execution/builtins.f90
+++ b/src/execution/builtins.f90
@@ -4505,11 +4505,19 @@ contains
       end if
     end if
 
-    ! Create temporary file with commands to edit
-    write(fmt_buf, '(a,i15)') '/tmp/fortsh_fc_', c_getpid()
-    tmpfile = trim(adjustl(fmt_buf))
+    ! Securely create the temp file to edit (mkstemp: random name, 0600, O_EXCL)
+    ! — not a predictable /tmp/fortsh_fc_<pid> open vulnerable to symlink/TOCTOU.
+    block
+      character(len=1024) :: tf
+      if (.not. make_temp_file('fortsh_fc_', tf)) then
+        write(error_unit, '(a)') 'fc: failed to create temporary file'
+        shell%last_exit_status = 1
+        return
+      end if
+      tmpfile = trim(tf)
+    end block
 
-    open(newunit=tmp_unit, file=trim(tmpfile), status='replace', action='write', iostat=iostat)
+    open(newunit=tmp_unit, file=trim(tmpfile), status='old', action='write', iostat=iostat)
     if (iostat /= 0) then
       write(error_unit, '(a)') 'fc: failed to create temporary file'
       shell%last_exit_status = 1

--- a/src/io/heredoc.f90
+++ b/src/io/heredoc.f90
@@ -398,21 +398,25 @@ contains
   end subroutine
 
   subroutine create_temp_file(filename, unit)
+    use system_interface, only: make_temp_file
     character(len=*), intent(out) :: filename
     integer, intent(out) :: unit
-    
-    character(len=32) :: pid_str
-    integer :: pid
-    
-    ! Create a unique temporary filename
-    pid = 1234  ! In real implementation, would get actual PID
-    write(pid_str, '(I0)') pid
-    filename = '/tmp/fortsh_heredoc_' // trim(pid_str) // '.tmp'
-    
-    open(newunit=unit, file=trim(filename), status='replace', action='write', iostat=unit)
-    if (unit /= 0) then
+    logical :: ok
+    integer :: ios
+
+    ! Securely create a unique temp file (mkstemp: random name, 0600, O_EXCL).
+    ! The old fixed /tmp/fortsh_heredoc_1234.tmp was a symlink/TOCTOU hazard,
+    ! and `iostat=unit` clobbered the newunit handle.
+    ok = make_temp_file('fortsh_heredoc_', filename)
+    if (.not. ok) then
       unit = -1
+      return
     end if
+
+    ! mkstemp already created the file (owned by us); open by its
+    ! unpredictable name to write the heredoc body.
+    open(newunit=unit, file=trim(filename), status='old', action='write', iostat=ios)
+    if (ios /= 0) unit = -1
   end subroutine
 
   subroutine create_temp_heredoc_file(content, filename)

--- a/src/io/readline.f90
+++ b/src/io/readline.f90
@@ -4131,8 +4131,9 @@ contains
 
       ! Print items in rows, aligned to columns
       do i = 1, num_completions
-        ! Print item padded to column width
-        write(output_unit, '(a)', advance='no') trim(completions(i))
+        ! Print item padded to column width (sanitize control/escape bytes in
+        ! filenames so they can't inject terminal escape sequences)
+        write(output_unit, '(a)', advance='no') sanitize_for_display(trim(completions(i)))
 
         ! Calculate position in current row
         items_in_row = mod(i - 1, num_cols) + 1
@@ -5215,8 +5216,10 @@ contains
       do col = 1, items_per_row
         if (item_idx > input_state%menu_num_items) exit
 
-        ! Copy item to local variable to avoid substring operations on array element
-        current_item = input_state%menu_items(item_idx)
+        ! Copy item to local variable to avoid substring operations on array element.
+        ! Sanitize control/escape bytes for DISPLAY only (insertion uses the real
+        ! menu_items value) so a malicious filename can't inject ANSI sequences.
+        current_item = sanitize_for_display(input_state%menu_items(item_idx))
         item_len = len_trim(current_item)
 
         ! Highlight selected item with reverse video

--- a/src/scripting/prompt_formatting.f90
+++ b/src/scripting/prompt_formatting.f90
@@ -220,12 +220,14 @@ contains
 
       ! Directory information
       case ('w')
-        ! Current working directory (full path, with ~ for HOME)
-        replacement = get_pretty_path(shell%cwd, shell)
+        ! Current working directory (full path, with ~ for HOME). Sanitize
+        ! control/escape bytes so a maliciously-named cwd can't inject ANSI
+        ! sequences into the prompt.
+        replacement = sanitize_for_display(get_pretty_path(shell%cwd, shell))
 
       case ('W')
-        ! Basename of current working directory
-        replacement = get_basename(shell%cwd)
+        ! Basename of current working directory (sanitized — see \w)
+        replacement = sanitize_for_display(get_basename(shell%cwd))
 
       ! Time and date
       case ('t')

--- a/src/system/interface.f90
+++ b/src/system/interface.f90
@@ -908,6 +908,23 @@ contains
     ok = (ret == 0)
   end function
 
+  ! Replace control/escape bytes (C0 except tab, DEL, and ESC) with '?' so that
+  ! untrusted text (filenames, cwd) printed to the terminal cannot inject ANSI
+  ! escape sequences. Same length out (preserves column alignment).
+  function sanitize_for_display(s) result(out)
+    character(len=*), intent(in) :: s
+    character(len=len(s)) :: out
+    integer :: i, c
+    do i = 1, len(s)
+      c = iachar(s(i:i))
+      if (c == 9 .or. (c >= 32 .and. c /= 127)) then
+        out(i:i) = s(i:i)
+      else
+        out(i:i) = '?'
+      end if
+    end do
+  end function
+
   ! Securely create a temp file (mkstemp: random name, O_EXCL, 0600, no symlink
   ! follow) and return its path. Replaces predictable /tmp/<fixed-name> opens
   ! that were vulnerable to symlink/TOCTOU attacks.

--- a/src/system/interface.f90
+++ b/src/system/interface.f90
@@ -396,6 +396,14 @@ module system_interface
       type(c_ptr) :: c_user_home
     end function
 
+    function c_make_temp(prefix, out, outlen) bind(C, name="fortsh_make_temp")
+      import :: c_char, c_int
+      character(kind=c_char), intent(in) :: prefix(*)
+      character(kind=c_char), intent(inout) :: out(*)
+      integer(c_int), value :: outlen
+      integer(c_int) :: c_make_temp
+    end function
+
     ! Native terminal size via ioctl done in C (src/c_interop/terminal_size.c),
     ! which avoids the flang-new crash on the Fortran c_loc(winsize) path.
     function c_get_term_size(rows, cols) bind(C, name="get_term_size_c")
@@ -898,6 +906,35 @@ contains
     rows = int(r)
     cols = int(c)
     ok = (ret == 0)
+  end function
+
+  ! Securely create a temp file (mkstemp: random name, O_EXCL, 0600, no symlink
+  ! follow) and return its path. Replaces predictable /tmp/<fixed-name> opens
+  ! that were vulnerable to symlink/TOCTOU attacks.
+  function make_temp_file(prefix, filename) result(ok)
+    character(len=*), intent(in) :: prefix
+    character(len=*), intent(out) :: filename
+    logical :: ok
+    character(kind=c_char), dimension(:), allocatable, target :: cprefix
+    character(kind=c_char), dimension(1024), target :: cout
+    integer :: i, plen, rc
+
+    filename = ''
+    plen = len_trim(prefix)
+    allocate(cprefix(plen + 1))
+    do i = 1, plen
+      cprefix(i) = prefix(i:i)
+    end do
+    cprefix(plen + 1) = c_null_char
+
+    rc = int(c_make_temp(cprefix, cout, 1024_c_int))
+    ok = (rc == 0)
+    if (ok) then
+      do i = 1, 1024
+        if (cout(i) == c_null_char) exit
+        if (i <= len(filename)) filename(i:i) = cout(i)
+      end do
+    end if
   end function
 
   ! Home directory for a named user via getpwnam (for ~user expansion).


### PR DESCRIPTION
Second batch from the audit (`.docs/audits/`), focused on the security findings. Local suite green: **POSIX 144/0, integration 479/0, completion 36/0, line_editing 49/0**.

## Fixes
- **Temp-file hardening (#42).** Heredoc temp files used a hardcoded path `/tmp/fortsh_heredoc_1234.tmp` (predictable name + `status='replace'` → symlink/TOCTOU), and `fc`'s temp used a predictable PID-based name. Both now go through a new `mkstemp`-based helper (`fortsh_make_temp` in `fd_wrapper.c` → `make_temp_file`): random name, `O_EXCL`, mode 0600, no symlink follow. Also fixed a latent bug where `open(newunit=unit, …, iostat=unit)` clobbered the unit handle.
- **ANSI-injection guard in completion display (#43).** A filename containing control/escape bytes, shown in the completion list/menu, could inject terminal escape sequences. The column list and the reverse-video menu now render through `sanitize_for_display` (control/C0-except-tab/DEL/ESC → `?`), display-only so insertion still uses the real value.
- **ANSI-injection guard in the prompt (#44).** `\w`/`\W` now sanitize the cwd value before substitution (a maliciously-named directory can't inject escapes into the prompt); the prompt's own color codes are untouched.

## New helpers (system_interface)
`make_temp_file`, `sanitize_for_display`, and the `fortsh_make_temp` C binding.

## Follow-up filed (not in this PR)
The *primary* completion-injection vector is **insertion**, not display: completing a filename with control bytes (single match / common prefix) puts raw bytes into the line buffer, which the redraw then emits. The proper fix is bash-style escaping of control/shell-special chars on completion insertion (tracked as #65) — bigger, deferred. This PR hardens the display + prompt paths.

Built & tested on FreeBSD (gfortran).