### PR TITLE
Audit fixes batch 4: RPROMPT, ANSI-C escapes, jobs, fzf, variable perf

### DIFF
--- a/src/execution/ast_executor.f90
+++ b/src/execution/ast_executor.f90
@@ -1536,12 +1536,11 @@ contains
                   shell%last_bg_pid = pid
                   ! Track job inline (duplicated code to avoid goto)
                   if (.not. shell%in_background) then
-                    job_command = trim(shell%current_command)
-                    if (len_trim(job_command) == 0 .and. associated(node%list%left%list%right)) then
+                    job_command = ''
+                    if (associated(node%list%left%list%right)) then
                       if (node%list%left%list%right%node_type == CMD_SIMPLE) then
                         if (associated(node%list%left%list%right%simple_cmd)) then
                           if (node%list%left%list%right%simple_cmd%num_words > 0) then
-                            job_command = ''
                             do i = 1, node%list%left%list%right%simple_cmd%num_words
                               if (i > 1) then
                                 job_command = trim(job_command) // ' ' // trim(node%list%left%list%right%simple_cmd%words(i))
@@ -1553,6 +1552,7 @@ contains
                         end if
                       end if
                     end if
+                    if (len_trim(job_command) == 0) job_command = trim(shell%current_command)
                     status = add_job(shell, pid, trim(job_command), .false.)
                     if (shell%is_interactive) then
                       write(output_unit, '(a,i0,a,i0)') '[', status, '] ', pid
@@ -1608,8 +1608,39 @@ contains
         shell%last_bg_pid = pid
         ! Only track jobs if we're not already in a background job child
         if (.not. shell%in_background) then
-          ! Use the current command text for job display
-          job_command = trim(shell%current_command)
+          ! Extract command text from the AST node, not the whole input line.
+          ! For nested background lists (a & b &), node%list%left is itself
+          ! a LIST(&) — drill into its left child to get the actual command.
+          job_command = ''
+          block
+            type(command_node_t), pointer :: cmd_node
+            cmd_node => null()
+            if (associated(node%list%left)) then
+              if (node%list%left%node_type == CMD_SIMPLE) then
+                cmd_node => node%list%left
+              else if (node%list%left%node_type == CMD_LIST .and. &
+                       associated(node%list%left%list)) then
+                if (node%list%left%list%separator == LIST_SEP_BACKGROUND .and. &
+                    associated(node%list%left%list%left)) then
+                  if (node%list%left%list%left%node_type == CMD_SIMPLE) then
+                    cmd_node => node%list%left%list%left
+                  end if
+                end if
+              end if
+            end if
+            if (associated(cmd_node)) then
+              if (associated(cmd_node%simple_cmd)) then
+                do i = 1, cmd_node%simple_cmd%num_words
+                  if (i > 1) then
+                    job_command = trim(job_command) // ' ' // trim(cmd_node%simple_cmd%words(i))
+                  else
+                    job_command = trim(cmd_node%simple_cmd%words(i))
+                  end if
+                end do
+              end if
+            end if
+          end block
+          if (len_trim(job_command) == 0) job_command = trim(shell%current_command)
           if (len_trim(job_command) == 0) job_command = '<background job>'
 
           status = add_job(shell, pid, trim(job_command), .false.)

--- a/src/execution/jobs.f90
+++ b/src/execution/jobs.f90
@@ -443,7 +443,7 @@ contains
               '[', shell%jobs(i)%job_id, ']', cur_mark, &
               trim(state_str), &
               repeat(' ', max(1, &
-                27 - len_trim(state_str))), &
+                24 - len_trim(state_str))), &
               trim(cmd_display)
           end if
         end block

--- a/src/io/readline.f90
+++ b/src/io/readline.f90
@@ -9109,9 +9109,9 @@ contains
     ! Build preview command
     if (len_trim(bat_path) > 0) then
       write(preview_cmd, '(a)') trim(bat_path) // &
-           ' --color=always --style=numbers,changes --line-range=:500 {}'
+           ' --color=always --style=numbers,changes --line-range=:500 "{}"'
     else
-      preview_cmd = 'head -n 500 {}'
+      preview_cmd = 'head -n 500 "{}"'
     end if
 
     ! Build fzf command with options (including multi-select)
@@ -9301,7 +9301,7 @@ contains
           'fd --type d --hidden --exclude .git || ' // &
           'find . -type d -not -path ''*/\.git/*'' 2>/dev/null) | ' // &
           'fzf --height=40% --reverse --border ' // &
-          '--preview=''ls -lah {}'' ' // &
+          '--preview=''ls -lah "{}"'' ' // &
           '--preview-window=right:60%:wrap ' // &
           '--header=''Alt-J: Jump to Directory | Select: CD into dir | ESC: Cancel'' ' // &
           '> /tmp/fortsh_fzf_dir.tmp 2>/dev/null'
@@ -9393,9 +9393,9 @@ contains
           'echo ""; echo "=== Branches ==="; ' // &
           'git branch --all; }'
 
-    write(preview_cmd, '(a)') 'if [[ {} == *"==="* ]]; then echo "Select an item below"; ' // &
-          'elif git show {}  >/dev/null 2>&1; then git show --stat {}; ' // &
-          'else git diff {}; fi'
+    write(preview_cmd, '(a)') 'if [[ "{}" == *"==="* ]]; then echo "Select an item below"; ' // &
+          'elif git show "{}" >/dev/null 2>&1; then git show --stat "{}"; ' // &
+          'else git diff "{}"; fi'
 
     write(fzf_cmd, '(a)') trim(git_cmd) // ' | ' // &
           'fzf --height=40% --reverse --border --ansi ' // &

--- a/src/io/readline.f90
+++ b/src/io/readline.f90
@@ -1353,6 +1353,7 @@ contains
     integer :: debug_stat
     ! Variables for RPROMPT (right-side prompt)
     integer :: rprompt_visual_len, padding_needed
+    logical :: rprompt_displayed
     ! Variables for multiline prompt support
     integer :: prompt_line_count
 
@@ -1434,6 +1435,7 @@ contains
 
     ! Check if we have RPROMPT and enough space
     ! Note: multi-line prompt RPROMPT is handled in fortsh.f90 by embedding into the prompt string
+    rprompt_displayed = .false.
     if (present(rprompt) .and. len_trim(rprompt) > 0) then
       rprompt_visual_len = visual_length(rprompt)
       if (rprompt_visual_len < 0) rprompt_visual_len = 0
@@ -1442,6 +1444,7 @@ contains
       padding_needed = term_cols - prompt_visual_len - 1 - rprompt_visual_len
 
       if (padding_needed >= 4) then  ! Minimum 4 chars gap
+        rprompt_displayed = .true.
         write(output_unit, '(a)', advance='no') prompt
         write(output_unit, '(a)', advance='no') ' '
 
@@ -1850,8 +1853,14 @@ contains
             ! Calculate current cursor position (add 1 for space after prompt)
             cursor_visual_pos = prompt_visual_len + 1 + module_input_state%cursor_pos
 
-            ! Calculate row/col from buffer state not stale screen tracking
-            current_row = cursor_visual_pos / term_cols
+            ! When RPROMPT was on the initial line, the entire terminal width
+            ! was filled (prompt + padding + rprompt). The first redraw must
+            ! account for this extra line of content that will be cleared.
+            if (rprompt_displayed) then
+              current_row = 1 + cursor_visual_pos / term_cols
+            else
+              current_row = cursor_visual_pos / term_cols
+            end if
             current_col = mod(cursor_visual_pos, term_cols)
             ! Calculate where start of prompt is (always row 0, col 0 of prompt line)
             ! === Buffered redraw: accumulate entire frame, write once ===
@@ -2008,6 +2017,10 @@ contains
             ! Show cursor, then flush entire buffer in one write
             call rdraw_append(ESC_SHOW_CURSOR)
             call rdraw_flush()
+
+            ! RPROMPT was cleared by ESC[J above; subsequent redraws
+            ! don't need the extra cursor-up compensation.
+            rprompt_displayed = .false.
 
             ! Debug: show state before recalculating cursor position
             if (debug_utf8) then

--- a/src/parsing/lexer.f90
+++ b/src/parsing/lexer.f90
@@ -475,6 +475,62 @@ contains
                 end if
                 cycle  ! pos already advanced past octal digits
               end block
+            case('u')
+              ! Unicode: \uHHHH (up to 4 hex digits) → UTF-8
+              block
+                integer :: uval, udigits
+                character :: uch
+                uval = 0; udigits = 0
+                pos = pos + 2
+                do while (pos <= input_len .and. udigits < 4)
+                  uch = input(pos:pos)
+                  if (uch >= '0' .and. uch <= '9') then
+                    uval = uval * 16 + (ichar(uch) - ichar('0'))
+                  else if (uch >= 'a' .and. uch <= 'f') then
+                    uval = uval * 16 + (ichar(uch) - ichar('a') + 10)
+                  else if (uch >= 'A' .and. uch <= 'F') then
+                    uval = uval * 16 + (ichar(uch) - ichar('A') + 10)
+                  else
+                    exit
+                  end if
+                  pos = pos + 1
+                  udigits = udigits + 1
+                end do
+                if (udigits > 0) call encode_utf8(uval, current_token, token_len)
+                cycle
+              end block
+            case('U')
+              ! Unicode: \UHHHHHHHH (up to 8 hex digits) → UTF-8
+              block
+                integer :: uval, udigits
+                character :: uch
+                uval = 0; udigits = 0
+                pos = pos + 2
+                do while (pos <= input_len .and. udigits < 8)
+                  uch = input(pos:pos)
+                  if (uch >= '0' .and. uch <= '9') then
+                    uval = uval * 16 + (ichar(uch) - ichar('0'))
+                  else if (uch >= 'a' .and. uch <= 'f') then
+                    uval = uval * 16 + (ichar(uch) - ichar('a') + 10)
+                  else if (uch >= 'A' .and. uch <= 'F') then
+                    uval = uval * 16 + (ichar(uch) - ichar('A') + 10)
+                  else
+                    exit
+                  end if
+                  pos = pos + 1
+                  udigits = udigits + 1
+                end do
+                if (udigits > 0) call encode_utf8(uval, current_token, token_len)
+                cycle
+              end block
+            case('c')
+              ! Control character: \cX → char(ichar(X) & 31)
+              if (pos + 2 <= input_len) then
+                token_len = token_len + 1
+                current_token(token_len:token_len) = char(iand(ichar(input(pos+2:pos+2)), 31))
+                pos = pos + 3
+                cycle
+              end if
             case default
               ! Unknown escape — keep both chars
               token_len = token_len + 1

--- a/src/scripting/variables.f90
+++ b/src/scripting/variables.f90
@@ -77,6 +77,15 @@ contains
       end if
     end if
 
+    ! Fast path: short lowercase names skip special-variable checks
+    if (len_trim(name) > 0 .and. len_trim(name) <= 3) then
+      block
+        character :: fc
+        fc = name(1:1)
+        if (fc >= 'a' .and. fc <= 'z') goto 200
+      end block
+    end if
+
     ! Handle special built-in variables
     select case (trim(name))
       case ('PS1')
@@ -155,6 +164,7 @@ contains
     end select
 
     ! Check if variable already exists
+200 continue
     do i = 1, shell%num_variables
       if (trim(shell%variables(i)%name) == trim(name)) then
         ! Check if variable is readonly
@@ -228,6 +238,23 @@ contains
           end do
         end if
       end do
+    end if
+
+    ! Fast path: regular alphabetic variables (a-z, A-Z) can skip special-
+    ! variable checks entirely — all special names are either non-alpha
+    ! single chars ($, !, ?, 0, _, -, #, *, @) or uppercase multi-char
+    ! (RANDOM, LINENO, etc.). A lowercase first char of length 1-3 is
+    ! almost certainly a loop variable; jump straight to the variable table.
+    if (len_trim(name) > 0) then
+      block
+        character :: fc
+        integer :: nlen
+        fc = name(1:1)
+        nlen = len_trim(name)
+        if ((fc >= 'a' .and. fc <= 'z') .and. nlen <= 3) then
+          goto 100
+        end if
+      end block
     end if
 
     ! Handle special variables
@@ -352,6 +379,7 @@ contains
     end if
     
     ! Handle regular shell variables
+100 continue
     do i = 1, shell%num_variables
       if (trim(shell%variables(i)%name) == trim(name)) then
         ! Use value_len to preserve trailing whitespace


### PR DESCRIPTION
## Summary
Five audit fixes, all regression-gated (POSIX 3776/3776, bench 204/204):

- **RPROMPT line-wrap duplication**: When RPROMPT filled the terminal width, the first keystroke duplicated the prompt because the redraw cursor-up calculation didn't account for the extra line. Track `rprompt_displayed` flag, add one row to cursor-up on first redraw, clear after ESC[J wipes it.
- **ANSI-C `$'...'` escapes**: Implement `\uHHHH` (4-digit Unicode), `\UHHHHHHHH` (8-digit), and `\cX` (control char) in the `LEX_IN_DOLLAR_SINGLE_QUOTE` state handler. Uses a new `encode_utf8` helper for multi-byte output. `$'☃'` → ☃, matching bash.
- **Variable lookup fast-path**: Short lowercase variable names (len ≤ 3, like loop counters `i`, `j`, `n`) skip the 20+ special-variable `select case` checks and go straight to the variable table.
- **Jobs display**: Background jobs showed the entire input line instead of the individual command. Extract command text from the AST node, drilling into nested background lists. Also fix column alignment to match bash exactly.
- **fzf preview quoting**: All `{}` placeholders in `--preview` commands were unquoted, breaking on filenames/branches with spaces or shell metacharacters. Quoted in file, directory, and git browsers.

## Test plan
- [x] POSIX full suite: 3776 pass, 0 fail (25/25 suites)
- [x] Bench/stress: 204 pass, 0 fail
- [x] Manual: `$'A'` → A, `$'☃'` → ☃, `$'\cA'` → 0x01
- [x] Manual: `sleep 1 & sleep 2 & jobs` shows individual commands
- [x] CI: 15-job matrix (Linux x86_64, ARM64, macOS ARM64)