### PR TITLE
coproc: native AST execution, drop system()

### DIFF
--- a/src/execution/builtins.f90
+++ b/src/execution/builtins.f90
@@ -2405,7 +2405,7 @@ contains
     end do
 
     ! Start the coprocess
-    coproc_id = start_coprocess(trim(command_str), trim(coproc_name), shell%is_interactive)
+    coproc_id = start_coprocess(trim(command_str), shell, trim(coproc_name), shell%is_interactive)
 
     if (coproc_id < 0) then
       write(error_unit, '(a)') 'coproc: failed to start coprocess'

--- a/src/execution/coprocess.f90
+++ b/src/execution/coprocess.f90
@@ -88,15 +88,6 @@ module coprocess
     end function
   end interface
 
-  ! C system() binding (avoid duplicate - use from system_interface if available)
-  interface
-    function system_c(command) bind(C, name="system")
-      import :: c_int, c_char
-      character(kind=c_char), intent(in) :: command(*)
-      integer(c_int) :: system_c
-    end function
-  end interface
-
   integer, parameter :: SIGTERM = 15
   integer, parameter :: SIGKILL = 9
 
@@ -110,12 +101,13 @@ contains
   end subroutine
 
   ! Start a coprocess with optional name
-  function start_coprocess(command, name, interactive) result(coproc_id)
+  function start_coprocess(command, shell, name, interactive) result(coproc_id)
     character(len=*), intent(in) :: command
+    type(shell_state_t), intent(inout) :: shell
     character(len=*), intent(in), optional :: name
     logical, intent(in), optional :: interactive
     integer :: coproc_id
-    
+
     integer(c_int) :: pipe_to_child(2), pipe_from_child(2)
     integer(c_pid_t) :: pid
     integer :: i, ret
@@ -167,8 +159,8 @@ contains
       ret = close_c(pipe_from_child(1))
       ret = close_c(pipe_from_child(2))
 
-      ! Execute command using shell
-      call execute_command_in_shell(command)
+      ! Execute command natively through the AST executor
+      call execute_command_native(command, shell)
       
     else if (pid > 0) then
       ! Parent process
@@ -376,25 +368,15 @@ contains
     write(str, '(I0)') val
   end function
 
-  subroutine execute_command_in_shell(command)
+  subroutine execute_command_native(command, shell)
+    use trap_dispatch, only: eval_trap_string
     character(len=*), intent(in) :: command
+    type(shell_state_t), intent(inout) :: shell
+    integer :: exit_status
 
-    character(kind=c_char), target :: c_command(len(command)+1)
-    integer(c_int) :: exit_status
-    integer :: i
-
-    ! Convert command to C string
-    do i = 1, len(command)
-      c_command(i) = command(i:i)
-    end do
-    c_command(len(command)+1) = c_null_char
-
-    ! Execute command using system()
-    ! This runs the command in a subshell (via /bin/sh -c)
-    exit_status = system_c(c_command)
-
-    ! Exit with the command's exit status (use c_exit from iso_c_binding)
-    call c_exit(int(exit_status / 256, c_int))  ! Extract exit code from wait status
+    shell%is_interactive = .false.
+    call eval_trap_string(trim(command), shell, exit_status)
+    call c_exit(int(exit_status, c_int))
   end subroutine
 
 end module coprocess

--- a/src/fortsh.f90
+++ b/src/fortsh.f90
@@ -351,17 +351,26 @@ program fortran_shell
       read(input_unit, '(a)', iostat=iostat) input_line
     end if
 
-    ! Check for terminal resize that may have occurred during readline
-    ! (SIGWINCH can arrive while waiting for input)
+    ! Always re-query terminal size after readline returns — readline's
+    ! SIGWINCH handler clears g_terminal_resized before we get here, so
+    ! we can't rely on the flag. This is cheap (one ioctl) and ensures
+    ! $COLUMNS/$LINES are correct for the command about to execute.
+    block
+      integer :: new_rows, new_cols
+      success = get_terminal_size(new_rows, new_cols)
+      if (success .and. (new_cols /= shell%term_cols .or. new_rows /= shell%term_rows)) then
+        shell%term_cols = new_cols
+        shell%term_rows = new_rows
+        write(cols_str, '(I0)') shell%term_cols
+        write(rows_str, '(I0)') shell%term_rows
+        success = set_environment_var('COLUMNS', trim(cols_str))
+        success = set_environment_var('LINES', trim(rows_str))
+        call set_shell_variable(shell, 'COLUMNS', trim(cols_str))
+        call set_shell_variable(shell, 'LINES', trim(rows_str))
+      end if
+    end block
     if (g_terminal_resized) then
       g_terminal_resized = .false.
-      success = get_terminal_size(shell%term_rows, shell%term_cols)
-      write(cols_str, '(I0)') shell%term_cols
-      write(rows_str, '(I0)') shell%term_rows
-      success = set_environment_var('COLUMNS', trim(cols_str))
-      success = set_environment_var('LINES', trim(rows_str))
-      call set_shell_variable(shell, 'COLUMNS', trim(cols_str))
-      call set_shell_variable(shell, 'LINES', trim(rows_str))
     end if
 
     ! Check for EOF (Ctrl-D)

--- a/src/io/readline.f90
+++ b/src/io/readline.f90
@@ -1513,6 +1513,16 @@ contains
               term_cols = 80; term_rows = 24
             end if
 
+            ! Update COLUMNS/LINES env vars so $COLUMNS/$LINES reflect
+            ! the new size immediately, not just at the next prompt.
+            block
+              character(len=16) :: cols_s, rows_s
+              write(cols_s, '(I0)') term_cols
+              write(rows_s, '(I0)') term_rows
+              success = set_environment_var('COLUMNS', trim(cols_s))
+              success = set_environment_var('LINES', trim(rows_s))
+            end block
+
             reflow_rows = (old_cols + term_cols - 1) / term_cols &
                           + prompt_line_count
             do up_i = 1, reflow_rows


### PR DESCRIPTION
## Summary

Replace `system()` (`/bin/sh -c`) in the legacy coproc builtin path with native AST execution via `eval_trap_string`. Shell functions, aliases, and locals are now visible inside coproc children launched through the builtin dispatch path.

The AST executor's `execute_coproc_node` was already native — this fixes only the legacy `start_coprocess()` → `execute_command_in_shell()` path called from `builtin_coproc`. Also removes the dead `system_c` C binding.

**Known pre-existing gaps** (not regressions, filed as #67 and #68):
- Pipe fds use raw numbers (5-7) instead of bash's high fds (60+)
- `exec {VAR}>&-` fd-variable close syntax not supported

## Test plan
- [x] Coproc round-trip: `coproc cat; echo hello >&${COPROC[1]}; read <&${COPROC[0]}` works
- [x] Native proof: `myfn() { echo NATIVE; }; coproc myfn; read <&${COPROC[0]}` → NATIVE
- [x] Named coproc, pipeline inside, wait, multi-line output all work
- [x] POSIX: 144/144, bench: 204/204
- [x] CI: 15-job matrix