### PR TITLE
Audit wave 2: lexer & parser correctness

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,20 @@ jobs:
           grep -q "pkgver = $ver\$" .SRCINFO                 || { echo ".SRCINFO pkgver mismatch"; fail=1; }
           exit $fail
 
+  bounds-check:
+    # OOB substring bugs in the lexer/parser only abort under
+    # -fcheck=bounds (MEM-1, DISC-2); release builds fail silently.
+    name: Bounds-Checked Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install gfortran
+        run: sudo apt-get update && sudo apt-get install -y gfortran
+      - name: Build debug (-fcheck=bounds)
+        run: make debug -j$(nproc)
+      - name: Bounds regression suite
+        run: ./tests/builtins/test_lexer_parser_bounds.sh
+
   posix-tests:
     name: POSIX Tests
     runs-on: ubuntu-latest

--- a/src/fortsh.f90
+++ b/src/fortsh.f90
@@ -973,8 +973,8 @@ contains
       ! Handle line continuation (backslash-newline)
       input_line = remove_line_continuations(input_line)
 
-      ! If EOF was reached during continuation, exit
-      if (iostat /= 0) exit
+      ! On EOF during continuation, still parse the remainder — an unclosed
+      ! quote must reach the parser to be rejected (exit 2), not be dropped.
 
       ! Check for unclosed compound commands (if/fi, do/done, case/esac)
       do while (needs_compound_continuation(input_line))

--- a/src/fortsh.f90
+++ b/src/fortsh.f90
@@ -818,35 +818,42 @@ contains
       content_end = 0
 
       j = content_pos
-      do while (j <= len_trim(input))
+      hd_scan: do while (j <= len_trim(input))
         ! Check if we're at start of a line
         if (j == content_pos .or. input(j-1:j-1) == char(10)) then
           ! For <<-, skip leading tabs before checking delimiter
           k = j
           if (strip_tabs) then
-            do while (k <= len_trim(input) .and. input(k:k) == char(9))
+            do while (k <= len_trim(input))
+              if (input(k:k) /= char(9)) exit
               k = k + 1
             end do
           end if
           ! Check if this line starts with the delimiter (after tabs if strip_tabs)
           if (k + len_trim(delimiter) - 1 <= len_trim(input)) then
             if (input(k:k+len_trim(delimiter)-1) == trim(delimiter)) then
-              ! Check if delimiter is alone on the line or followed by newline
-              if (k + len_trim(delimiter) > len_trim(input) .or. &
-                  input(k+len_trim(delimiter):k+len_trim(delimiter)) == char(10)) then
-                content_end = j - 1
-                content_pos = k + len_trim(delimiter)
-                if (content_pos <= len_trim(input) .and. &
-                    input(content_pos:content_pos) == char(10)) then
-                  content_pos = content_pos + 1
+              ! Delimiter must be alone on the line or followed by newline.
+              ! Bounds check split from the read: .or. does not short-circuit.
+              block
+                logical :: delim_line_end
+                integer :: dpos
+                dpos = k + len_trim(delimiter)
+                delim_line_end = (dpos > len_trim(input))
+                if (.not. delim_line_end) delim_line_end = (input(dpos:dpos) == char(10))
+                if (delim_line_end) then
+                  content_end = j - 1
+                  content_pos = dpos
+                  if (content_pos <= len_trim(input)) then
+                    if (input(content_pos:content_pos) == char(10)) content_pos = content_pos + 1
+                  end if
+                  exit hd_scan
                 end if
-                exit
-              end if
+              end block
             end if
           end if
         end if
         j = j + 1
-      end do
+      end do hd_scan
 
       ! Extract heredoc content
       if (content_end >= content_start) then

--- a/src/fortsh.f90
+++ b/src/fortsh.f90
@@ -38,7 +38,10 @@ program fortran_shell
   character(len=MAX_VAR_VALUE_LEN) :: rprompt_str ! Right-side prompt (like zsh RPROMPT)
   character(len=:), allocatable :: rprompt_value  ! RPROMPT variable value
   integer :: iostat, num_args, arg_idx, cmd_string_idx
-  character(len=MAX_PATH_LEN) :: arg1, command_string
+  character(len=MAX_PATH_LEN) :: arg1
+  ! Allocated to the actual -c argument length so long command strings are
+  ! not clipped at MAX_PATH_LEN (PARSE-5)
+  character(len=:), allocatable :: command_string
   logical :: execute_command_string, execute_script_file, syntax_check_only
   logical :: no_rc_file
   character(len=:), allocatable :: script_file
@@ -113,7 +116,12 @@ program fortran_shell
 
     case ('-c')
       if (arg_idx + 1 <= num_args) then
-        call get_command_argument(arg_idx + 1, command_string)
+        block
+          integer :: c_arg_len
+          call get_command_argument(arg_idx + 1, length=c_arg_len)
+          allocate(character(len=c_arg_len) :: command_string)
+          call get_command_argument(arg_idx + 1, command_string)
+        end block
         cmd_string_idx = arg_idx + 1
         execute_command_string = .true.
         ! Arguments after the command string become $0 and positional

--- a/src/parsing/grammar_parser.f90
+++ b/src/parsing/grammar_parser.f90
@@ -72,6 +72,15 @@ contains
     end if
     state%raw_input = input  ! Save for heredoc parsing
     call tokenize(input, state%tokens, state%num_tokens)
+    if (last_tokenize_unterminated .and. .not. g_parser_interactive) then
+      ! bash exits 2 on EOF inside an unclosed construct; interactive mode
+      ! never gets here — the REPL gathers continuation lines first.
+      call write_stderr(parser_err_prefix()//'unexpected EOF while looking for matching `'// &
+                        last_unterminated_closer//"'")
+      last_parse_had_error = .true.
+      nullify(root)
+      return
+    end if
     state%pos = 1
     root => parse_complete_command(state)
     if (state%has_error .and. associated(root)) then

--- a/src/parsing/grammar_parser.f90
+++ b/src/parsing/grammar_parser.f90
@@ -267,6 +267,38 @@ contains
     end do
   end function
 
+  ! Desugar |& — bash defines cmd |& next as cmd 2>&1 | next, so append a
+  ! 2>&1 (dup fd 2 onto 1) to the command left of the pipe. Simple commands
+  ! carry redirects on simple_cmd; compound nodes on the node itself.
+  subroutine attach_stderr_merge(node)
+    type(command_node_t), pointer :: node
+    type(redirection_t), allocatable :: tmp(:)
+    integer :: n
+
+    if (.not. associated(node)) return
+    if (node%node_type == CMD_SIMPLE .and. associated(node%simple_cmd)) then
+      n = node%simple_cmd%num_redirects
+      allocate(tmp(n + 1))
+      if (n > 0) tmp(1:n) = node%simple_cmd%redirects(1:n)
+      tmp(n + 1)%type = REDIR_DUP_OUT
+      tmp(n + 1)%fd = 2
+      tmp(n + 1)%target_fd = 1
+      if (allocated(node%simple_cmd%redirects)) deallocate(node%simple_cmd%redirects)
+      call move_alloc(tmp, node%simple_cmd%redirects)
+      node%simple_cmd%num_redirects = n + 1
+    else
+      n = node%num_redirects
+      allocate(tmp(n + 1))
+      if (n > 0) tmp(1:n) = node%redirects(1:n)
+      tmp(n + 1)%type = REDIR_DUP_OUT
+      tmp(n + 1)%fd = 2
+      tmp(n + 1)%target_fd = 1
+      if (allocated(node%redirects)) deallocate(node%redirects)
+      call move_alloc(tmp, node%redirects)
+      node%num_redirects = n + 1
+    end if
+  end subroutine attach_stderr_merge
+
   recursive function parse_pipeline_node(state) result(node)
     type(parser_state_t), intent(inout) :: state
     type(command_node_t), pointer :: node, temp_node, commands(:)
@@ -284,11 +316,14 @@ contains
     node => parse_command_node(state)
     if (.not. associated(node)) return
     tok = current_token(state)
-    if (tok%token_type == TOKEN_OPERATOR .and. trim(tok%value) == '|') then
+    if (tok%token_type == TOKEN_OPERATOR .and. &
+        (trim(tok%value) == '|' .or. trim(tok%value) == '|&')) then
       allocate(commands(16))
       num_commands = 1
+      if (trim(tok%value) == '|&') call attach_stderr_merge(node)
       commands(1) = node
-      do while (tok%token_type == TOKEN_OPERATOR .and. trim(tok%value) == '|')
+      do while (tok%token_type == TOKEN_OPERATOR .and. &
+                (trim(tok%value) == '|' .or. trim(tok%value) == '|&'))
         call advance(state)
         call skip_newlines(state)
         temp_node => parse_command_node(state)
@@ -312,9 +347,13 @@ contains
             commands => tmp
           end block
         end if
+        tok = current_token(state)
+        ! A following |& means THIS stage pipes stderr too
+        if (tok%token_type == TOKEN_OPERATOR .and. trim(tok%value) == '|&') then
+          call attach_stderr_merge(temp_node)
+        end if
         num_commands = num_commands + 1
         commands(num_commands) = temp_node
-        tok = current_token(state)
       end do
       if (state%has_error) then
         ! Error occurred - return null

--- a/src/parsing/grammar_parser.f90
+++ b/src/parsing/grammar_parser.f90
@@ -81,6 +81,14 @@ contains
       nullify(root)
       return
     end if
+    if (last_tokenize_truncated) then
+      ! token_t%value is a fixed 4096-byte buffer; running the clipped word
+      ! would silently change semantics, so reject the input instead (MEM-5).
+      call write_stderr(parser_err_prefix()//'word too long (limit 4096 bytes)')
+      last_parse_had_error = .true.
+      nullify(root)
+      return
+    end if
     state%pos = 1
     root => parse_complete_command(state)
     if (state%has_error .and. associated(root)) then
@@ -298,6 +306,42 @@ contains
       node%num_redirects = n + 1
     end if
   end subroutine attach_stderr_merge
+
+  ! Double the simple-command word arrays when full so words past the
+  ! initial capacity are kept instead of silently dropped (PARSE-5).
+  subroutine grow_cmd_words(words, was_quoted, was_escaped, quote_types, word_lens, num_words)
+    character(len=MAX_TOKEN_LEN), allocatable, intent(inout) :: words(:)
+    logical, allocatable, intent(inout) :: was_quoted(:), was_escaped(:)
+    integer, allocatable, intent(inout) :: quote_types(:), word_lens(:)
+    integer, intent(in) :: num_words
+    character(len=MAX_TOKEN_LEN), allocatable :: wtmp(:)
+    logical, allocatable :: ltmp(:)
+    integer, allocatable :: itmp(:)
+    integer :: n
+
+    if (num_words < size(words)) return
+    n = size(words)
+    allocate(wtmp(n * 2)); wtmp(1:n) = words; call move_alloc(wtmp, words)
+    allocate(ltmp(n * 2)); ltmp = .false.; ltmp(1:n) = was_quoted; call move_alloc(ltmp, was_quoted)
+    allocate(ltmp(n * 2)); ltmp = .false.; ltmp(1:n) = was_escaped; call move_alloc(ltmp, was_escaped)
+    allocate(itmp(n * 2)); itmp = QUOTE_NONE; itmp(1:n) = quote_types; call move_alloc(itmp, quote_types)
+    allocate(itmp(n * 2)); itmp = 0; itmp(1:n) = word_lens; call move_alloc(itmp, word_lens)
+  end subroutine grow_cmd_words
+
+  ! Same for the two-array for-loop word list.
+  subroutine grow_for_words(words, quote_types, num_words)
+    character(len=MAX_TOKEN_LEN), allocatable, intent(inout) :: words(:)
+    integer, allocatable, intent(inout) :: quote_types(:)
+    integer, intent(in) :: num_words
+    character(len=MAX_TOKEN_LEN), allocatable :: wtmp(:)
+    integer, allocatable :: itmp(:)
+    integer :: n
+
+    if (num_words < size(words)) return
+    n = size(words)
+    allocate(wtmp(n * 2)); wtmp(1:n) = words; call move_alloc(wtmp, words)
+    allocate(itmp(n * 2)); itmp = QUOTE_NONE; itmp(1:n) = quote_types; call move_alloc(itmp, quote_types)
+  end subroutine grow_for_words
 
   recursive function parse_pipeline_node(state) result(node)
     type(parser_state_t), intent(inout) :: state
@@ -609,7 +653,8 @@ contains
               end if
             else
               ! This is a regular word (assignment after command name)
-              if (num_words < MAX_TOKENS) then
+              call grow_cmd_words(words, was_quoted, was_escaped, quote_types, word_lens, num_words)
+              if (num_words < size(words)) then
                 num_words = num_words + 1
                 words(num_words) = merged_word
                 was_quoted(num_words) = next_tok%quoted
@@ -630,7 +675,8 @@ contains
               assignments(num_assignments) = tok%value
               assignment_lens(num_assignments) = tok%end_pos - tok%start_pos + 1
             else
-              if (num_words < MAX_TOKENS) then
+              call grow_cmd_words(words, was_quoted, was_escaped, quote_types, word_lens, num_words)
+              if (num_words < size(words)) then
                 num_words = num_words + 1
                 words(num_words) = tok%value
                 was_quoted(num_words) = tok%quoted
@@ -664,7 +710,8 @@ contains
           else
             ! Regular word - this is the command or an argument
             seen_command = .true.
-            if (num_words < MAX_TOKENS) then
+            call grow_cmd_words(words, was_quoted, was_escaped, quote_types, word_lens, num_words)
+            if (num_words < size(words)) then
               num_words = num_words + 1
               words(num_words) = tok%value
               was_quoted(num_words) = tok%quoted
@@ -1071,7 +1118,8 @@ contains
       call advance(state)
       tok = current_token(state)
       do while (tok%token_type == TOKEN_WORD)
-        if (num_words < MAX_TOKENS) then
+        call grow_for_words(words, quote_types, num_words)
+        if (num_words < size(words)) then
           num_words = num_words + 1
           words(num_words) = tok%value
           quote_types(num_words) = tok%quote_type

--- a/src/parsing/grammar_parser.f90
+++ b/src/parsing/grammar_parser.f90
@@ -1448,8 +1448,10 @@ contains
     ! POSIX: Empty subshell () is a syntax error
     if (.not. associated(commands)) then
       call write_stderr(parser_err_prefix() // "syntax error near unexpected token `)'")
-      if (allocated(state%raw_input)) then
-        call write_stderr("sh: -c: `" // trim(state%raw_input) // "'")
+      ! bash's second line (the echoed input) carries the same prefix and
+      ! only appears in non-interactive mode
+      if (.not. g_parser_interactive .and. allocated(state%raw_input)) then
+        call write_stderr(parser_err_prefix() // '`' // trim(state%raw_input) // "'")
       end if
       state%has_error = .true.
       return

--- a/src/parsing/lexer.f90
+++ b/src/parsing/lexer.f90
@@ -601,60 +601,9 @@ contains
           ! Scan to find matching ), respecting nested parens and quotes
           do while (pos <= input_len .and. paren_depth > 0)
             ch = input(pos:pos)
-            if (ch == '"') then
-              ! Skip double-quoted string inside command substitution
-              if (token_len < MAX_TOKEN_LEN) then
-                token_len = token_len + 1
-                current_token(token_len:token_len) = ch
-              end if
-              pos = pos + 1
-              do while (pos <= input_len)
-                ch = input(pos:pos)
-                if (ch == '\' .and. pos < input_len) then
-                  ! Skip escaped char
-                  if (token_len < MAX_TOKEN_LEN - 1) then
-                    token_len = token_len + 1
-                    current_token(token_len:token_len) = ch
-                    token_len = token_len + 1
-                    current_token(token_len:token_len) = input(pos+1:pos+1)
-                  end if
-                  pos = pos + 2
-                else if (ch == '"') then
-                  if (token_len < MAX_TOKEN_LEN) then
-                    token_len = token_len + 1
-                    current_token(token_len:token_len) = ch
-                  end if
-                  pos = pos + 1
-                  exit
-                else
-                  if (token_len < MAX_TOKEN_LEN) then
-                    token_len = token_len + 1
-                    current_token(token_len:token_len) = ch
-                  end if
-                  pos = pos + 1
-                end if
-              end do
-            else if (ch == "'") then
-              ! Skip single-quoted string
-              if (token_len < MAX_TOKEN_LEN) then
-                token_len = token_len + 1
-                current_token(token_len:token_len) = ch
-              end if
-              pos = pos + 1
-              do while (pos <= input_len .and. input(pos:pos) /= "'")
-                if (token_len < MAX_TOKEN_LEN) then
-                  token_len = token_len + 1
-                  current_token(token_len:token_len) = input(pos:pos)
-                end if
-                pos = pos + 1
-              end do
-              if (pos <= input_len) then
-                if (token_len < MAX_TOKEN_LEN) then
-                  token_len = token_len + 1
-                  current_token(token_len:token_len) = "'"
-                end if
-                pos = pos + 1
-              end if
+            if (ch == '"' .or. ch == "'") then
+              ! Quoted span - a ')' between quotes must not close the substitution
+              call consume_quoted_span(input, input_len, pos, current_token, token_len)
             else if (ch == '(') then
               paren_depth = paren_depth + 1
               if (token_len < MAX_TOKEN_LEN) then
@@ -748,6 +697,9 @@ contains
               current_token(token_len:token_len) = ch
             end if
             pos = pos + 1
+          else if (ch == '"' .or. ch == "'") then
+            ! Quoted span - a ')' between quotes must not close the substitution
+            call consume_quoted_span(input, input_len, pos, current_token, token_len)
           else if (ch == ')') then
             paren_depth = paren_depth - 1
             if (token_len < MAX_TOKEN_LEN) then
@@ -1250,6 +1202,51 @@ contains
     call add_token(tokens, num_tokens, TOKEN_EOF, '', input_len+1, input_len+1, .false.)
 
   end subroutine tokenize
+
+  ! Consume a quoted span inside $(...) verbatim, from the opening quote at
+  ! input(pos:pos) through its closing quote, appending to current_token.
+  ! Callers use this so paren accounting never sees a ')' between quotes.
+  ! Inside double quotes a backslash escapes the next character; single
+  ! quotes take everything literally.
+  subroutine consume_quoted_span(input, input_len, pos, current_token, token_len)
+    character(len=*), intent(in) :: input
+    integer, intent(in) :: input_len
+    integer, intent(inout) :: pos, token_len
+    character(len=*), intent(inout) :: current_token
+    character :: quote_ch, ch
+
+    quote_ch = input(pos:pos)
+    if (token_len < MAX_TOKEN_LEN) then
+      token_len = token_len + 1
+      current_token(token_len:token_len) = quote_ch
+    end if
+    pos = pos + 1
+    do while (pos <= input_len)
+      ch = input(pos:pos)
+      if (quote_ch == '"' .and. ch == '\' .and. pos < input_len) then
+        if (token_len < MAX_TOKEN_LEN - 1) then
+          token_len = token_len + 1
+          current_token(token_len:token_len) = ch
+          token_len = token_len + 1
+          current_token(token_len:token_len) = input(pos+1:pos+1)
+        end if
+        pos = pos + 2
+      else if (ch == quote_ch) then
+        if (token_len < MAX_TOKEN_LEN) then
+          token_len = token_len + 1
+          current_token(token_len:token_len) = ch
+        end if
+        pos = pos + 1
+        return
+      else
+        if (token_len < MAX_TOKEN_LEN) then
+          token_len = token_len + 1
+          current_token(token_len:token_len) = ch
+        end if
+        pos = pos + 1
+      end if
+    end do
+  end subroutine consume_quoted_span
 
   ! =====================================
   ! Helper: Add token to array

--- a/src/parsing/lexer.f90
+++ b/src/parsing/lexer.f90
@@ -466,7 +466,9 @@ contains
                   pos = pos + 1
                   hdigits = hdigits + 1
                 end do
-                if (hdigits > 0 .and. hval <= 255) then
+                if (hdigits > 0 .and. hval == 0) then
+                  call skip_ansi_c_remainder(input, input_len, pos)
+                else if (hdigits > 0 .and. hval <= 255) then
                   token_len = token_len + 1
                   current_token(token_len:token_len) = char(hval)
                 end if
@@ -489,7 +491,9 @@ contains
                   pos = pos + 1
                   odigits = odigits + 1
                 end do
-                if (odigits > 0 .and. oval <= 255) then
+                if (odigits > 0 .and. oval == 0) then
+                  call skip_ansi_c_remainder(input, input_len, pos)
+                else if (odigits > 0 .and. oval <= 255) then
                   token_len = token_len + 1
                   current_token(token_len:token_len) = char(oval)
                 end if
@@ -516,7 +520,11 @@ contains
                   pos = pos + 1
                   udigits = udigits + 1
                 end do
-                if (udigits > 0) call encode_utf8(uval, current_token, token_len)
+                if (udigits > 0 .and. uval == 0) then
+                  call skip_ansi_c_remainder(input, input_len, pos)
+                else if (udigits > 0) then
+                  call encode_utf8(uval, current_token, token_len)
+                end if
                 cycle
               end block
             case('U')
@@ -540,7 +548,11 @@ contains
                   pos = pos + 1
                   udigits = udigits + 1
                 end do
-                if (udigits > 0) call encode_utf8(uval, current_token, token_len)
+                if (udigits > 0 .and. uval == 0) then
+                  call skip_ansi_c_remainder(input, input_len, pos)
+                else if (udigits > 0) then
+                  call encode_utf8(uval, current_token, token_len)
+                end if
                 cycle
               end block
             case('c')
@@ -1100,6 +1112,25 @@ contains
 
   end subroutine tokenize
 
+  ! Skip the rest of a $'...' segment after an escape resolved to NUL.
+  ! bash drops everything from the NUL to the closing quote but keeps
+  ! adjacent segments of the same word ($'a\0b'post yields "apost").
+  ! Leaves pos at the closing quote so the caller's normal close path runs.
+  subroutine skip_ansi_c_remainder(input, input_len, pos)
+    character(len=*), intent(in) :: input
+    integer, intent(in) :: input_len
+    integer, intent(inout) :: pos
+
+    do while (pos <= input_len)
+      if (input(pos:pos) == "'") return
+      if (input(pos:pos) == '\' .and. pos < input_len) then
+        pos = pos + 2
+      else
+        pos = pos + 1
+      end if
+    end do
+  end subroutine skip_ansi_c_remainder
+
   ! Append one character to the token buffer, or record the truncation.
   subroutine append_ch(buf, buf_len, c)
     character(len=*), intent(inout) :: buf
@@ -1358,7 +1389,9 @@ contains
               exit
             end if
           end do
-          if (oct_val > 0 .and. oct_val <= 127) then
+          if (n_digits > 0 .and. oct_val == 0) then
+            call skip_ansi_c_remainder(input, input_len, pos)
+          else if (oct_val > 0 .and. oct_val <= 255) then
             call append_ch(current_token, token_len, char(oct_val))
           end if
         case('x')
@@ -1384,7 +1417,9 @@ contains
               exit
             end if
           end do
-          if (hex_val > 0 .and. hex_val <= 127) then
+          if (n_digits > 0 .and. hex_val == 0) then
+            call skip_ansi_c_remainder(input, input_len, pos)
+          else if (hex_val > 0 .and. hex_val <= 255) then
             call append_ch(current_token, token_len, char(hex_val))
           end if
         case('u')
@@ -1406,7 +1441,11 @@ contains
             pos = pos + 1
             n_digits = n_digits + 1
           end do
-          call encode_utf8(hex_val, current_token, token_len)
+          if (n_digits > 0 .and. hex_val == 0) then
+            call skip_ansi_c_remainder(input, input_len, pos)
+          else
+            call encode_utf8(hex_val, current_token, token_len)
+          end if
         case('U')
           ! Unicode: \UHHHHHHHH (8 hex digits) → UTF-8
           hex_val = 0
@@ -1426,7 +1465,11 @@ contains
             pos = pos + 1
             n_digits = n_digits + 1
           end do
-          call encode_utf8(hex_val, current_token, token_len)
+          if (n_digits > 0 .and. hex_val == 0) then
+            call skip_ansi_c_remainder(input, input_len, pos)
+          else
+            call encode_utf8(hex_val, current_token, token_len)
+          end if
         case('c')
           ! Control character: \cX → char(ichar(X) & 31)
           if (pos + 2 <= input_len) then

--- a/src/parsing/lexer.f90
+++ b/src/parsing/lexer.f90
@@ -542,11 +542,13 @@ contains
                 cycle
               end if
             case default
-              ! Unknown escape — keep both chars
-              token_len = token_len + 1
-              current_token(token_len:token_len) = ch
-              token_len = token_len + 1
-              current_token(token_len:token_len) = next_ch
+              ! Unknown escape — keep both chars (needs two bytes of headroom)
+              if (token_len < MAX_TOKEN_LEN - 1) then
+                token_len = token_len + 1
+                current_token(token_len:token_len) = ch
+                token_len = token_len + 1
+                current_token(token_len:token_len) = next_ch
+              end if
             end select
           end if
           pos = pos + 2

--- a/src/parsing/lexer.f90
+++ b/src/parsing/lexer.f90
@@ -21,6 +21,8 @@ module lexer
   public :: peek_token
   public :: is_keyword
   public :: is_operator
+  public :: last_tokenize_unterminated
+  public :: last_unterminated_closer
 
   ! Lexer state enumeration
   integer, parameter :: LEX_NORMAL = 1
@@ -33,6 +35,15 @@ module lexer
   ! Context tracking for [[ ]] test expressions
   ! Inside [[ ]], && || < > are test operators, not shell operators
   logical :: in_double_bracket_context = .false.
+
+  ! Set when tokenize hits end of input inside an unclosed quote, $'...',
+  ! $(, ${, or <(/>( — the closer is the character bash names in its
+  ! "unexpected EOF while looking for matching" diagnostic. tokenize has no
+  ! status argument, so parse_command_line reads these to reject the input
+  ! in non-interactive mode; the interactive REPL resolves unterminated
+  ! constructs upstream with continuation lines.
+  logical :: last_tokenize_unterminated = .false.
+  character(len=1) :: last_unterminated_closer = ' '
 
 contains
 
@@ -146,6 +157,8 @@ contains
     continuing_word = .false.
     token_has_quoted_part = .false.
     in_double_bracket_context = .false.
+    last_tokenize_unterminated = .false.
+    last_unterminated_closer = ' '
 
     do while (pos <= input_len .and. num_tokens < size(tokens))
       ch = input(pos:pos)
@@ -1183,17 +1196,36 @@ contains
 
     ! Flush any remaining token
     if (state == LEX_IN_WORD .and. token_len > 0) then
+      if (paren_depth > 0) then
+        ! Still inside $(, ${, or <(/>( at end of input
+        last_tokenize_unterminated = .true.
+        if (index(current_token(1:token_len), '${') > 0 .and. &
+            index(current_token(1:token_len), '$(') == 0) then
+          last_unterminated_closer = '}'
+        else
+          last_unterminated_closer = ')'
+        end if
+      end if
       call add_word_or_keyword(tokens, num_tokens, current_token(1:token_len), &
                               token_start, input_len, token_has_quoted_part, in_escape)
     else if (state == LEX_IN_SINGLE_QUOTE .or. state == LEX_IN_DOUBLE_QUOTE) then
       ! Unterminated quote - add as word with error marker
+      last_tokenize_unterminated = .true.
       if (state == LEX_IN_SINGLE_QUOTE) then
+        last_unterminated_closer = "'"
         call add_token(tokens, num_tokens, TOKEN_WORD, current_token(1:token_len), &
                     token_start, input_len, .true., quote_type=QUOTE_SINGLE)
       else
+        last_unterminated_closer = '"'
         call add_token(tokens, num_tokens, TOKEN_WORD, current_token(1:token_len), &
                     token_start, input_len, .true., quote_type=QUOTE_DOUBLE)
       end if
+    else if (state == LEX_IN_DOLLAR_SINGLE_QUOTE) then
+      ! Unterminated $'...' at end of input
+      last_tokenize_unterminated = .true.
+      last_unterminated_closer = "'"
+      call add_token(tokens, num_tokens, TOKEN_WORD, current_token(1:token_len), &
+                  token_start, input_len, .true., quote_type=QUOTE_SINGLE)
     else if (state == LEX_IN_OPERATOR .and. token_len > 0) then
       ! Flush operator
       call add_token(tokens, num_tokens, TOKEN_OPERATOR, current_token(1:token_len), &
@@ -1581,6 +1613,8 @@ contains
     end do
 
     ! Unterminated $'...' - add sentinel anyway
+    last_tokenize_unterminated = .true.
+    last_unterminated_closer = "'"
     if (token_len < MAX_TOKEN_LEN) then
       token_len = token_len + 1
       current_token(token_len:token_len) = char(3)

--- a/src/parsing/lexer.f90
+++ b/src/parsing/lexer.f90
@@ -23,6 +23,7 @@ module lexer
   public :: is_operator
   public :: last_tokenize_unterminated
   public :: last_unterminated_closer
+  public :: last_tokenize_truncated
 
   ! Lexer state enumeration
   integer, parameter :: LEX_NORMAL = 1
@@ -44,6 +45,13 @@ module lexer
   ! constructs upstream with continuation lines.
   logical :: last_tokenize_unterminated = .false.
   character(len=1) :: last_unterminated_closer = ' '
+
+  ! Set when any append would exceed MAX_TOKEN_LEN. token_t%value is fixed
+  ! at 4096 bytes, so over-long words cannot be grown here; instead of
+  ! silently clipping (the old behavior), parse_command_line rejects the
+  ! input with a diagnostic. All append sites go through append_ch /
+  ! append_two so this flag and the bounds guard cannot drift per-site.
+  logical :: last_tokenize_truncated = .false.
 
 contains
 
@@ -136,7 +144,7 @@ contains
   ! =====================================
   subroutine tokenize(input, tokens, num_tokens)
     character(len=*), intent(in) :: input
-    type(token_t), intent(out) :: tokens(:)
+    type(token_t), allocatable, intent(inout) :: tokens(:)
     integer, intent(out) :: num_tokens
 
     integer :: pos, input_len, state, token_start
@@ -159,8 +167,9 @@ contains
     in_double_bracket_context = .false.
     last_tokenize_unterminated = .false.
     last_unterminated_closer = ' '
+    last_tokenize_truncated = .false.
 
-    do while (pos <= input_len .and. num_tokens < size(tokens))
+    do while (pos <= input_len)
       ch = input(pos:pos)
 
       ! Get next character for lookahead (if available)
@@ -269,10 +278,7 @@ contains
           do while (pos <= input_len .and. paren_depth > 0)
             if (input(pos:pos) == '(') paren_depth = paren_depth + 1
             if (input(pos:pos) == ')') paren_depth = paren_depth - 1
-            if (token_len < MAX_TOKEN_LEN) then
-              token_len = token_len + 1
-              current_token(token_len:token_len) = input(pos:pos)
-            end if
+            call append_ch(current_token, token_len, input(pos:pos))
             pos = pos + 1
           end do
           cycle
@@ -338,10 +344,7 @@ contains
         if (ch == "'") then
           ! End of single-quoted string
           ! Add sentinel char(3) to mark end of single-quoted literal
-          if (token_len < MAX_TOKEN_LEN) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = char(3)
-          end if
+          call append_ch(current_token, token_len, char(3))
           pos = pos + 1  ! Move past closing quote
           ! Check if next character continues the word (adjacent quote, word char, or escape)
           if (pos <= input_len) then
@@ -376,10 +379,7 @@ contains
           end if
         else
           ! Add character to token (everything is literal)
-          if (token_len < MAX_TOKEN_LEN) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = ch
-          end if
+          call append_ch(current_token, token_len, ch)
           pos = pos + 1
         end if
 
@@ -387,10 +387,7 @@ contains
       case(LEX_IN_DOLLAR_SINGLE_QUOTE)
         if (ch == "'") then
           ! End of $'...' string — add sentinels to mark as quoted
-          if (token_len < MAX_TOKEN_LEN) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = char(3)  ! end sentinel
-          end if
+          call append_ch(current_token, token_len, char(3))  ! end sentinel
           pos = pos + 1
           ! Check if next character continues the word
           if (pos <= input_len) then
@@ -556,21 +553,15 @@ contains
               end if
             case default
               ! Unknown escape — keep both chars (needs two bytes of headroom)
-              if (token_len < MAX_TOKEN_LEN - 1) then
-                token_len = token_len + 1
-                current_token(token_len:token_len) = ch
-                token_len = token_len + 1
-                current_token(token_len:token_len) = next_ch
-              end if
+              call append_two(current_token, token_len, ch, next_ch)
             end select
+          else
+            last_tokenize_truncated = .true.
           end if
           pos = pos + 2
         else
           ! Regular character — add literally
-          if (token_len < MAX_TOKEN_LEN) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = ch
-          end if
+          call append_ch(current_token, token_len, ch)
           pos = pos + 1
         end if
 
@@ -580,37 +571,21 @@ contains
           ! Backslash escape in double quotes (only for $, `, ", \, newline)
           if (next_ch == '$' .or. next_ch == '`') then
             ! For \$ and \` - keep BOTH chars so expansion can see the escape
-            if (token_len < MAX_TOKEN_LEN - 1) then
-              token_len = token_len + 1
-              current_token(token_len:token_len) = ch
-              token_len = token_len + 1
-              current_token(token_len:token_len) = next_ch
-            end if
+            call append_two(current_token, token_len, ch, next_ch)
             pos = pos + 2
           else if (next_ch == '"' .or. next_ch == '\' .or. next_ch == char(10)) then
             ! For \" and \\ and \newline - add only escaped character
-            if (token_len < MAX_TOKEN_LEN) then
-              token_len = token_len + 1
-              current_token(token_len:token_len) = next_ch
-            end if
+            call append_ch(current_token, token_len, next_ch)
             pos = pos + 2
           else
             ! Backslash is literal
-            if (token_len < MAX_TOKEN_LEN) then
-              token_len = token_len + 1
-              current_token(token_len:token_len) = ch
-            end if
+            call append_ch(current_token, token_len, ch)
             pos = pos + 1
           end if
         else if (ch == '$' .and. pos < input_len .and. next_ch == '(') then
           ! Command substitution inside double quotes - need to find matching )
           ! while ignoring quotes inside $()
-          if (token_len < MAX_TOKEN_LEN - 1) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = '$'
-            token_len = token_len + 1
-            current_token(token_len:token_len) = '('
-          end if
+          call append_two(current_token, token_len, '$', '(')
           pos = pos + 2
           paren_depth = 1
           ! Scan to find matching ), respecting nested parens and quotes
@@ -621,23 +596,14 @@ contains
               call consume_quoted_span(input, input_len, pos, current_token, token_len)
             else if (ch == '(') then
               paren_depth = paren_depth + 1
-              if (token_len < MAX_TOKEN_LEN) then
-                token_len = token_len + 1
-                current_token(token_len:token_len) = ch
-              end if
+              call append_ch(current_token, token_len, ch)
               pos = pos + 1
             else if (ch == ')') then
               paren_depth = paren_depth - 1
-              if (token_len < MAX_TOKEN_LEN) then
-                token_len = token_len + 1
-                current_token(token_len:token_len) = ch
-              end if
+              call append_ch(current_token, token_len, ch)
               pos = pos + 1
             else
-              if (token_len < MAX_TOKEN_LEN) then
-                token_len = token_len + 1
-                current_token(token_len:token_len) = ch
-              end if
+              call append_ch(current_token, token_len, ch)
               pos = pos + 1
             end if
           end do
@@ -650,30 +616,21 @@ contains
             if (next_ch == "'" .or. next_ch == '"') then
               ! Adjacent quote follows - continue building this token
               ! Add sentinel to mark quote boundary (so expansion knows where quoted part ends)
-              if (token_len < MAX_TOKEN_LEN) then
-                token_len = token_len + 1
-                current_token(token_len:token_len) = char(1)  ! ASCII SOH as sentinel
-              end if
+              call append_ch(current_token, token_len, char(1))  ! ASCII SOH as sentinel
               state = LEX_IN_WORD
               continuing_word = .false.
               cycle
             else if (next_ch == '\') then
               ! Backslash escape follows - continue building this token
               ! Add sentinel to mark quote boundary
-              if (token_len < MAX_TOKEN_LEN) then
-                token_len = token_len + 1
-                current_token(token_len:token_len) = char(1)  ! ASCII SOH as sentinel
-              end if
+              call append_ch(current_token, token_len, char(1))  ! ASCII SOH as sentinel
               state = LEX_IN_WORD
               continuing_word = .false.
               cycle
             else if (is_word_char(next_ch)) then
               ! Word character follows - continue building this token
               ! Add sentinel to mark quote boundary (so expansion knows where quoted part ends)
-              if (token_len < MAX_TOKEN_LEN) then
-                token_len = token_len + 1
-                current_token(token_len:token_len) = char(1)  ! ASCII SOH as sentinel
-              end if
+              call append_ch(current_token, token_len, char(1))  ! ASCII SOH as sentinel
               state = LEX_IN_WORD
               continuing_word = .false.
               cycle
@@ -692,10 +649,7 @@ contains
           end if
         else
           ! Add character to token
-          if (token_len < MAX_TOKEN_LEN) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = ch
-          end if
+          call append_ch(current_token, token_len, ch)
           pos = pos + 1
         end if
 
@@ -707,20 +661,14 @@ contains
           ! Inside command substitution - track paren depth
           if (ch == '(') then
             paren_depth = paren_depth + 1
-            if (token_len < MAX_TOKEN_LEN) then
-              token_len = token_len + 1
-              current_token(token_len:token_len) = ch
-            end if
+            call append_ch(current_token, token_len, ch)
             pos = pos + 1
           else if (ch == '"' .or. ch == "'") then
             ! Quoted span - a ')' between quotes must not close the substitution
             call consume_quoted_span(input, input_len, pos, current_token, token_len)
           else if (ch == ')') then
             paren_depth = paren_depth - 1
-            if (token_len < MAX_TOKEN_LEN) then
-              token_len = token_len + 1
-              current_token(token_len:token_len) = ch
-            end if
+            call append_ch(current_token, token_len, ch)
             pos = pos + 1
             ! If paren_depth hits 0, we closed the $(...)
             if (paren_depth == 0) then
@@ -751,10 +699,7 @@ contains
             end if
           else
             ! Inside $() - keep EVERYTHING including spaces
-            if (token_len < MAX_TOKEN_LEN) then
-              token_len = token_len + 1
-              current_token(token_len:token_len) = ch
-            end if
+            call append_ch(current_token, token_len, ch)
             pos = pos + 1
           end if
         ! Check if we're inside ${ - if so, keep EVERYTHING until closing }
@@ -763,17 +708,11 @@ contains
           ! Inside parameter expansion - track brace depth
           if (ch == '{') then
             paren_depth = paren_depth + 1
-            if (token_len < MAX_TOKEN_LEN) then
-              token_len = token_len + 1
-              current_token(token_len:token_len) = ch
-            end if
+            call append_ch(current_token, token_len, ch)
             pos = pos + 1
           else if (ch == '}') then
             paren_depth = paren_depth - 1
-            if (token_len < MAX_TOKEN_LEN) then
-              token_len = token_len + 1
-              current_token(token_len:token_len) = ch
-            end if
+            call append_ch(current_token, token_len, ch)
             pos = pos + 1
             ! If paren_depth hits 0, we closed the ${...}
             if (paren_depth == 0) then
@@ -808,27 +747,16 @@ contains
             end if
           else
             ! Inside ${ - keep EVERYTHING including spaces
-            if (token_len < MAX_TOKEN_LEN) then
-              token_len = token_len + 1
-              current_token(token_len:token_len) = ch
-            end if
+            call append_ch(current_token, token_len, ch)
             pos = pos + 1
           end if
         else if (ch == '\' .and. pos < input_len) then
           ! Backslash escape in word
           ! For expansion-triggering chars, preserve backslash
           if (next_ch == '$' .or. next_ch == '`') then
-            if (token_len < MAX_TOKEN_LEN - 1) then
-              token_len = token_len + 1
-              current_token(token_len:token_len) = '\'
-              token_len = token_len + 1
-              current_token(token_len:token_len) = next_ch
-            end if
+            call append_two(current_token, token_len, '\', next_ch)
           else
-            if (token_len < MAX_TOKEN_LEN) then
-              token_len = token_len + 1
-              current_token(token_len:token_len) = next_ch
-            end if
+            call append_ch(current_token, token_len, next_ch)
           end if
           pos = pos + 2
         else if (ch == "'" .or. ch == '"') then
@@ -856,10 +784,7 @@ contains
               cycle
             end if
             ! Add sentinel char(2) to mark start of single-quoted literal (no expansion)
-            if (token_len < MAX_TOKEN_LEN) then
-              token_len = token_len + 1
-              current_token(token_len:token_len) = char(2)
-            end if
+            call append_ch(current_token, token_len, char(2))
             state = LEX_IN_SINGLE_QUOTE
           else
             state = LEX_IN_DOUBLE_QUOTE
@@ -871,147 +796,87 @@ contains
           ! which is handled in the NORMAL state. So `echo a#b` -> a#b, and
           ! `$#` stays the parameter. `echo a #b` still comments (the space
           ! ends the word first, then '#' is seen in the NORMAL state).
-          if (token_len < MAX_TOKEN_LEN) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = ch
-          end if
+          call append_ch(current_token, token_len, ch)
           pos = pos + 1
         else if (ch == '$' .and. pos < input_len .and. next_ch == '(') then
           ! $( for command/arithmetic substitution - keep in word
-          if (token_len < MAX_TOKEN_LEN - 1) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = ch
-            token_len = token_len + 1
-            current_token(token_len:token_len) = next_ch
-            paren_depth = 1  ! Track that we're inside $(
-          end if
+          call append_two(current_token, token_len, ch, next_ch)
+          paren_depth = 1  ! Track that we're inside $(
           pos = pos + 2
         else if (ch == '$' .and. pos < input_len .and. next_ch == '{') then
           ! ${ for parameter expansion - keep in word
-          if (token_len < MAX_TOKEN_LEN - 1) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = ch
-            token_len = token_len + 1
-            current_token(token_len:token_len) = next_ch
-            paren_depth = 1  ! Track that we're inside ${
-          end if
+          call append_two(current_token, token_len, ch, next_ch)
+          paren_depth = 1  ! Track that we're inside ${
           pos = pos + 2
         else if ((ch >= '0' .and. ch <= '9') .or. ch == '+' .or. ch == '-' .or. &
                  ch == '*' .or. ch == '/' .or. ch == '%') then
           ! Keep these chars in word (for variables and arithmetic)
-          if (token_len < MAX_TOKEN_LEN) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = ch
-          end if
+          call append_ch(current_token, token_len, ch)
           pos = pos + 1
         else if (ch == '(' .or. ch == ')') then
           ! Inside [[ ]], keep parens as part of word (regex patterns, grouping)
           if (in_double_bracket_context) then
-            if (token_len < MAX_TOKEN_LEN) then
-              token_len = token_len + 1
-              current_token(token_len:token_len) = ch
-            end if
+            call append_ch(current_token, token_len, ch)
             pos = pos + 1
           ! Parentheses: Keep ONLY if inside $(( or $(
           ! Check if current token ends with $ (for x=$(cmd) or just $(cmd))
           ! NOTE: Only for '(' - ')' after $ (like $$) should end the word
           else if (ch == '(' .and. token_len >= 1 .and. current_token(token_len:token_len) == '$') then
             ! Just added $, now seeing ( - this is $( substitution - keep both
-            if (token_len < MAX_TOKEN_LEN) then
-              token_len = token_len + 1
-              current_token(token_len:token_len) = ch
-            end if
+            call append_ch(current_token, token_len, ch)
             pos = pos + 1
           else if (token_len >= 2 .and. index(current_token(1:token_len), '$(') > 0) then
             ! Already inside $(...) - keep parens
-            if (token_len < MAX_TOKEN_LEN) then
-              token_len = token_len + 1
-              current_token(token_len:token_len) = ch
-            end if
+            call append_ch(current_token, token_len, ch)
             pos = pos + 1
           else if (ch == '(' .and. token_len >= 1 .and. &
                    current_token(token_len:token_len) == '=') then
             ! Array assignment: VAR=(...) - include the parenthesized content
             ! Scan for matching ) respecting quotes and nested parens
-            if (token_len < MAX_TOKEN_LEN) then
-              token_len = token_len + 1
-              current_token(token_len:token_len) = '('
-            end if
+            call append_ch(current_token, token_len, '(')
             pos = pos + 1
             paren_depth = 1
             do while (pos <= input_len .and. paren_depth > 0)
               ch = input(pos:pos)
               if (ch == '"') then
                 ! Skip double-quoted string
-                if (token_len < MAX_TOKEN_LEN) then
-                  token_len = token_len + 1
-                  current_token(token_len:token_len) = ch
-                end if
+                call append_ch(current_token, token_len, ch)
                 pos = pos + 1
                 do while (pos <= input_len .and. input(pos:pos) /= '"')
                   if (input(pos:pos) == '\' .and. pos < input_len) then
-                    if (token_len < MAX_TOKEN_LEN - 1) then
-                      token_len = token_len + 1
-                      current_token(token_len:token_len) = input(pos:pos)
-                      token_len = token_len + 1
-                      current_token(token_len:token_len) = input(pos+1:pos+1)
-                    end if
+                    call append_two(current_token, token_len, input(pos:pos), input(pos+1:pos+1))
                     pos = pos + 2
                   else
-                    if (token_len < MAX_TOKEN_LEN) then
-                      token_len = token_len + 1
-                      current_token(token_len:token_len) = input(pos:pos)
-                    end if
+                    call append_ch(current_token, token_len, input(pos:pos))
                     pos = pos + 1
                   end if
                 end do
                 if (pos <= input_len) then
-                  if (token_len < MAX_TOKEN_LEN) then
-                    token_len = token_len + 1
-                    current_token(token_len:token_len) = '"'
-                  end if
+                  call append_ch(current_token, token_len, '"')
                   pos = pos + 1
                 end if
               else if (ch == "'") then
                 ! Skip single-quoted string
-                if (token_len < MAX_TOKEN_LEN) then
-                  token_len = token_len + 1
-                  current_token(token_len:token_len) = ch
-                end if
+                call append_ch(current_token, token_len, ch)
                 pos = pos + 1
                 do while (pos <= input_len .and. input(pos:pos) /= "'")
-                  if (token_len < MAX_TOKEN_LEN) then
-                    token_len = token_len + 1
-                    current_token(token_len:token_len) = input(pos:pos)
-                  end if
+                  call append_ch(current_token, token_len, input(pos:pos))
                   pos = pos + 1
                 end do
                 if (pos <= input_len) then
-                  if (token_len < MAX_TOKEN_LEN) then
-                    token_len = token_len + 1
-                    current_token(token_len:token_len) = "'"
-                  end if
+                  call append_ch(current_token, token_len, "'")
                   pos = pos + 1
                 end if
               else if (ch == '(') then
                 paren_depth = paren_depth + 1
-                if (token_len < MAX_TOKEN_LEN) then
-                  token_len = token_len + 1
-                  current_token(token_len:token_len) = ch
-                end if
+                call append_ch(current_token, token_len, ch)
                 pos = pos + 1
               else if (ch == ')') then
                 paren_depth = paren_depth - 1
-                if (token_len < MAX_TOKEN_LEN) then
-                  token_len = token_len + 1
-                  current_token(token_len:token_len) = ch
-                end if
+                call append_ch(current_token, token_len, ch)
                 pos = pos + 1
               else
-                if (token_len < MAX_TOKEN_LEN) then
-                  token_len = token_len + 1
-                  current_token(token_len:token_len) = ch
-                end if
+                call append_ch(current_token, token_len, ch)
                 pos = pos + 1
               end if
             end do
@@ -1032,26 +897,17 @@ contains
         else if (ch == '{' .or. ch == '}') then
           ! Braces: Keep in word for brace expansion (e.g., {1,2,3} or file{a,b}.txt)
           ! They're only command group operators when surrounded by whitespace
-          if (token_len < MAX_TOKEN_LEN) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = ch
-          end if
+          call append_ch(current_token, token_len, ch)
           pos = pos + 1
         else if (in_double_bracket_context .and. &
                  (ch == '&' .or. ch == '|' .or. ch == '<' .or. ch == '>' .or. &
                   ch == '(' .or. ch == ')')) then
           ! Inside [[ ]], these are test operators, not shell operators
-          if (token_len < MAX_TOKEN_LEN) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = ch
-          end if
+          call append_ch(current_token, token_len, ch)
           pos = pos + 1
         else if (is_word_char(ch)) then
           ! Continue word
-          if (token_len < MAX_TOKEN_LEN) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = ch
-          end if
+          call append_ch(current_token, token_len, ch)
           pos = pos + 1
         else
           ! End of word
@@ -1244,6 +1100,36 @@ contains
 
   end subroutine tokenize
 
+  ! Append one character to the token buffer, or record the truncation.
+  subroutine append_ch(buf, buf_len, c)
+    character(len=*), intent(inout) :: buf
+    integer, intent(inout) :: buf_len
+    character(len=1), intent(in) :: c
+
+    if (buf_len < MAX_TOKEN_LEN) then
+      buf_len = buf_len + 1
+      buf(buf_len:buf_len) = c
+    else
+      last_tokenize_truncated = .true.
+    end if
+  end subroutine append_ch
+
+  ! Append two characters (escape pairs) — both or neither.
+  subroutine append_two(buf, buf_len, c1, c2)
+    character(len=*), intent(inout) :: buf
+    integer, intent(inout) :: buf_len
+    character(len=1), intent(in) :: c1, c2
+
+    if (buf_len < MAX_TOKEN_LEN - 1) then
+      buf_len = buf_len + 1
+      buf(buf_len:buf_len) = c1
+      buf_len = buf_len + 1
+      buf(buf_len:buf_len) = c2
+    else
+      last_tokenize_truncated = .true.
+    end if
+  end subroutine append_two
+
   ! Consume a quoted span inside $(...) verbatim, from the opening quote at
   ! input(pos:pos) through its closing quote, appending to current_token.
   ! Callers use this so paren accounting never sees a ')' between quotes.
@@ -1257,33 +1143,19 @@ contains
     character :: quote_ch, ch
 
     quote_ch = input(pos:pos)
-    if (token_len < MAX_TOKEN_LEN) then
-      token_len = token_len + 1
-      current_token(token_len:token_len) = quote_ch
-    end if
+    call append_ch(current_token, token_len, quote_ch)
     pos = pos + 1
     do while (pos <= input_len)
       ch = input(pos:pos)
       if (quote_ch == '"' .and. ch == '\' .and. pos < input_len) then
-        if (token_len < MAX_TOKEN_LEN - 1) then
-          token_len = token_len + 1
-          current_token(token_len:token_len) = ch
-          token_len = token_len + 1
-          current_token(token_len:token_len) = input(pos+1:pos+1)
-        end if
+        call append_two(current_token, token_len, ch, input(pos+1:pos+1))
         pos = pos + 2
       else if (ch == quote_ch) then
-        if (token_len < MAX_TOKEN_LEN) then
-          token_len = token_len + 1
-          current_token(token_len:token_len) = ch
-        end if
+        call append_ch(current_token, token_len, ch)
         pos = pos + 1
         return
       else
-        if (token_len < MAX_TOKEN_LEN) then
-          token_len = token_len + 1
-          current_token(token_len:token_len) = ch
-        end if
+        call append_ch(current_token, token_len, ch)
         pos = pos + 1
       end if
     end do
@@ -1294,7 +1166,7 @@ contains
   ! =====================================
   subroutine add_token(tokens, num_tokens, tok_type, value, start_pos, end_pos, quoted, escaped, quote_type)
     use shell_types, only: QUOTE_NONE
-    type(token_t), intent(inout) :: tokens(:)
+    type(token_t), allocatable, intent(inout) :: tokens(:)
     integer, intent(inout) :: num_tokens
     integer, intent(in) :: tok_type, start_pos, end_pos
     character(len=*), intent(in) :: value
@@ -1302,6 +1174,15 @@ contains
     logical, intent(in), optional :: escaped
     integer, intent(in), optional :: quote_type
 
+    ! Grow instead of silently dropping tokens past the initial capacity
+    if (num_tokens >= size(tokens)) then
+      block
+        type(token_t), allocatable :: tmp(:)
+        allocate(tmp(size(tokens) * 2))
+        tmp(1:num_tokens) = tokens(1:num_tokens)
+        call move_alloc(tmp, tokens)
+      end block
+    end if
     if (num_tokens < size(tokens)) then
       num_tokens = num_tokens + 1
       tokens(num_tokens)%token_type = tok_type
@@ -1327,7 +1208,7 @@ contains
   ! Helper: Add word or keyword token
   ! =====================================
   subroutine add_word_or_keyword(tokens, num_tokens, value, start_pos, end_pos, quoted, escaped)
-    type(token_t), intent(inout) :: tokens(:)
+    type(token_t), allocatable, intent(inout) :: tokens(:)
     integer, intent(inout) :: num_tokens
     character(len=*), intent(in) :: value
     integer, intent(in) :: start_pos, end_pos
@@ -1412,10 +1293,7 @@ contains
     integer :: oct_val, hex_val, n_digits
 
     ! Add sentinel to mark start of quoted content (no expansion)
-    if (token_len < MAX_TOKEN_LEN) then
-      token_len = token_len + 1
-      current_token(token_len:token_len) = char(2)
-    end if
+    call append_ch(current_token, token_len, char(2))
 
     do while (pos <= input_len)
       ch = input(pos:pos)
@@ -1424,10 +1302,7 @@ contains
         ! Closing quote
         pos = pos + 1
         ! Add sentinel to mark end of quoted content
-        if (token_len < MAX_TOKEN_LEN) then
-          token_len = token_len + 1
-          current_token(token_len:token_len) = char(3)
-        end if
+        call append_ch(current_token, token_len, char(3))
         return
       end if
 
@@ -1436,70 +1311,37 @@ contains
         esc_ch = input(pos+1:pos+1)
         select case(esc_ch)
         case('a')   ! Alert (bell)
-          if (token_len < MAX_TOKEN_LEN) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = char(7)
-          end if
+          call append_ch(current_token, token_len, char(7))
           pos = pos + 2
         case('b')   ! Backspace
-          if (token_len < MAX_TOKEN_LEN) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = char(8)
-          end if
+          call append_ch(current_token, token_len, char(8))
           pos = pos + 2
         case('e', 'E')  ! Escape
-          if (token_len < MAX_TOKEN_LEN) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = char(27)
-          end if
+          call append_ch(current_token, token_len, char(27))
           pos = pos + 2
         case('f')   ! Form feed
-          if (token_len < MAX_TOKEN_LEN) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = char(12)
-          end if
+          call append_ch(current_token, token_len, char(12))
           pos = pos + 2
         case('n')   ! Newline
-          if (token_len < MAX_TOKEN_LEN) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = char(10)
-          end if
+          call append_ch(current_token, token_len, char(10))
           pos = pos + 2
         case('r')   ! Carriage return
-          if (token_len < MAX_TOKEN_LEN) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = char(13)
-          end if
+          call append_ch(current_token, token_len, char(13))
           pos = pos + 2
         case('t')   ! Horizontal tab
-          if (token_len < MAX_TOKEN_LEN) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = char(9)
-          end if
+          call append_ch(current_token, token_len, char(9))
           pos = pos + 2
         case('v')   ! Vertical tab
-          if (token_len < MAX_TOKEN_LEN) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = char(11)
-          end if
+          call append_ch(current_token, token_len, char(11))
           pos = pos + 2
         case('\')   ! Literal backslash
-          if (token_len < MAX_TOKEN_LEN) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = '\'
-          end if
+          call append_ch(current_token, token_len, '\')
           pos = pos + 2
         case("'")   ! Literal single quote
-          if (token_len < MAX_TOKEN_LEN) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = "'"
-          end if
+          call append_ch(current_token, token_len, "'")
           pos = pos + 2
         case('"')   ! Literal double quote
-          if (token_len < MAX_TOKEN_LEN) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = '"'
-          end if
+          call append_ch(current_token, token_len, '"')
           pos = pos + 2
         case('0', '1', '2', '3', '4', '5', '6', '7')
           ! Octal: \nnn (up to 3 digits)
@@ -1516,9 +1358,8 @@ contains
               exit
             end if
           end do
-          if (oct_val > 0 .and. oct_val <= 127 .and. token_len < MAX_TOKEN_LEN) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = char(oct_val)
+          if (oct_val > 0 .and. oct_val <= 127) then
+            call append_ch(current_token, token_len, char(oct_val))
           end if
         case('x')
           ! Hex: \xHH (up to 2 digits)
@@ -1543,9 +1384,8 @@ contains
               exit
             end if
           end do
-          if (hex_val > 0 .and. hex_val <= 127 .and. token_len < MAX_TOKEN_LEN) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = char(hex_val)
+          if (hex_val > 0 .and. hex_val <= 127) then
+            call append_ch(current_token, token_len, char(hex_val))
           end if
         case('u')
           ! Unicode: \uHHHH (4 hex digits) → UTF-8
@@ -1591,30 +1431,19 @@ contains
           ! Control character: \cX → char(ichar(X) & 31)
           if (pos + 2 <= input_len) then
             ch = input(pos+2:pos+2)
-            if (token_len < MAX_TOKEN_LEN) then
-              token_len = token_len + 1
-              current_token(token_len:token_len) = char(iand(ichar(ch), 31))
-            end if
+            call append_ch(current_token, token_len, char(iand(ichar(ch), 31)))
             pos = pos + 3
           else
             pos = pos + 2
           end if
         case default
           ! Unknown escape: include backslash and character literally
-          if (token_len < MAX_TOKEN_LEN - 1) then
-            token_len = token_len + 1
-            current_token(token_len:token_len) = '\'
-            token_len = token_len + 1
-            current_token(token_len:token_len) = esc_ch
-          end if
+          call append_two(current_token, token_len, '\', esc_ch)
           pos = pos + 2
         end select
       else
         ! Regular character
-        if (token_len < MAX_TOKEN_LEN) then
-          token_len = token_len + 1
-          current_token(token_len:token_len) = ch
-        end if
+        call append_ch(current_token, token_len, ch)
         pos = pos + 1
       end if
     end do
@@ -1622,10 +1451,7 @@ contains
     ! Unterminated $'...' - add sentinel anyway
     last_tokenize_unterminated = .true.
     last_unterminated_closer = "'"
-    if (token_len < MAX_TOKEN_LEN) then
-      token_len = token_len + 1
-      current_token(token_len:token_len) = char(3)
-    end if
+    call append_ch(current_token, token_len, char(3))
   end subroutine process_ansi_c_quote
 
   subroutine encode_utf8(codepoint, buf, buf_len)
@@ -1635,16 +1461,15 @@ contains
 
     if (codepoint < 0) return
     if (codepoint <= 127) then
-      if (buf_len < MAX_TOKEN_LEN) then
-        buf_len = buf_len + 1
-        buf(buf_len:buf_len) = char(codepoint)
-      end if
+      call append_ch(buf, buf_len, char(codepoint))
     else if (codepoint <= int(z'7FF')) then
       if (buf_len + 1 < MAX_TOKEN_LEN) then
         buf_len = buf_len + 1
         buf(buf_len:buf_len) = char(ior(int(z'C0'), ishft(codepoint, -6)))
         buf_len = buf_len + 1
         buf(buf_len:buf_len) = char(ior(int(z'80'), iand(codepoint, int(z'3F'))))
+      else
+        last_tokenize_truncated = .true.
       end if
     else if (codepoint <= int(z'FFFF')) then
       if (buf_len + 2 < MAX_TOKEN_LEN) then
@@ -1654,6 +1479,8 @@ contains
         buf(buf_len:buf_len) = char(ior(int(z'80'), iand(ishft(codepoint, -6), int(z'3F'))))
         buf_len = buf_len + 1
         buf(buf_len:buf_len) = char(ior(int(z'80'), iand(codepoint, int(z'3F'))))
+      else
+        last_tokenize_truncated = .true.
       end if
     else if (codepoint <= int(z'10FFFF')) then
       if (buf_len + 3 < MAX_TOKEN_LEN) then
@@ -1665,6 +1492,8 @@ contains
         buf(buf_len:buf_len) = char(ior(int(z'80'), iand(ishft(codepoint, -6), int(z'3F'))))
         buf_len = buf_len + 1
         buf(buf_len:buf_len) = char(ior(int(z'80'), iand(codepoint, int(z'3F'))))
+      else
+        last_tokenize_truncated = .true.
       end if
     end if
   end subroutine encode_utf8

--- a/src/parsing/lexer.f90
+++ b/src/parsing/lexer.f90
@@ -1086,6 +1086,13 @@ contains
               call add_token(tokens, num_tokens, TOKEN_OPERATOR, '||', token_start, pos, .false.)
               state = LEX_NORMAL
               pos = pos + 1
+            else if (ch == '&') then
+              ! |& pipes stdout+stderr (bash shorthand for 2>&1 |)
+              current_token(2:2) = ch
+              token_len = 2
+              call add_token(tokens, num_tokens, TOKEN_OPERATOR, '|&', token_start, pos, .false.)
+              state = LEX_NORMAL
+              pos = pos + 1
             else
               call add_token(tokens, num_tokens, TOKEN_OPERATOR, '|', token_start, pos-1, .false.)
               state = LEX_NORMAL

--- a/src/parsing/lexer.f90
+++ b/src/parsing/lexer.f90
@@ -200,7 +200,8 @@ contains
         ! Comments: # to end of line
         if (ch == '#') then
           ! Skip until newline or end of input
-          do while (pos <= input_len .and. input(pos:pos) /= char(10))
+          do while (pos <= input_len)
+            if (input(pos:pos) == char(10)) exit
             pos = pos + 1
           end do
           cycle
@@ -854,7 +855,8 @@ contains
                 ! Skip double-quoted string
                 call append_ch(current_token, token_len, ch)
                 pos = pos + 1
-                do while (pos <= input_len .and. input(pos:pos) /= '"')
+                do while (pos <= input_len)
+                  if (input(pos:pos) == '"') exit
                   if (input(pos:pos) == '\' .and. pos < input_len) then
                     call append_two(current_token, token_len, input(pos:pos), input(pos+1:pos+1))
                     pos = pos + 2
@@ -871,7 +873,8 @@ contains
                 ! Skip single-quoted string
                 call append_ch(current_token, token_len, ch)
                 pos = pos + 1
-                do while (pos <= input_len .and. input(pos:pos) /= "'")
+                do while (pos <= input_len)
+                  if (input(pos:pos) == "'") exit
                   call append_ch(current_token, token_len, input(pos:pos))
                   pos = pos + 1
                 end do

--- a/src/parsing/parser.f90
+++ b/src/parsing/parser.f90
@@ -1275,6 +1275,30 @@ contains
     end do
   end function
 
+  ! Advance i from an opening quote at str(i:i) to just past its closing
+  ! quote, so paren scans never see a ')' between quotes. Inside double
+  ! quotes a backslash escapes the next character; single quotes are literal.
+  subroutine skip_quoted_span(str, i)
+    character(len=*), intent(in) :: str
+    integer, intent(inout) :: i
+    character :: quote_ch
+    integer :: n
+
+    n = len_trim(str)
+    quote_ch = str(i:i)
+    i = i + 1
+    do while (i <= n)
+      if (quote_ch == '"' .and. str(i:i) == '\' .and. i < n) then
+        i = i + 2
+      else if (str(i:i) == quote_ch) then
+        i = i + 1
+        return
+      else
+        i = i + 1
+      end if
+    end do
+  end subroutine skip_quoted_span
+
   subroutine expand_variables(token, expanded, shell, was_quoted_in)
     use expansion, only: expand_braces, arithmetic_expansion_shell, process_param_expansion
     character(len=*), intent(in) :: token
@@ -1603,6 +1627,11 @@ contains
             brace_depth = 1
 
             do while (i <= len_trim(working_token) .and. brace_depth > 0)
+              if (working_token(i:i) == '"' .or. working_token(i:i) == "'") then
+                ! Quoted span - a ')' between quotes must not close the substitution
+                call skip_quoted_span(working_token, i)
+                cycle
+              end if
               if (working_token(i:i) == '(') then
                 brace_depth = brace_depth + 1
               else if (working_token(i:i) == ')') then

--- a/src/parsing/parser.f90
+++ b/src/parsing/parser.f90
@@ -332,7 +332,7 @@ contains
           end block  ! amp_not_after_special bounds-safe check
         else if (working_input(i:i) == ';') then
           ! Check for ;; (double semicolon) which is used in case statements
-          if (i < len_trim(working_input) .and. working_input(i+1:i+1) == ';') then
+          if (char_follows(working_input, i, ';')) then
             ! This is ;; - inside case statements it's a pattern terminator
             if (case_depth > 0) then
               cmd_count = cmd_count + 1
@@ -1275,6 +1275,51 @@ contains
     end do
   end function
 
+  ! True when str(i+1:i+1) exists and equals ch. Bounds check runs in a
+  ! separate statement because .and. does not short-circuit: str(i+1:i+1)
+  ! is out of bounds when i is the last character.
+  function char_follows(str, i, ch) result(res)
+    character(len=*), intent(in) :: str
+    integer, intent(in) :: i
+    character, intent(in) :: ch
+    logical :: res
+
+    res = .false.
+    if (i + 1 > len_trim(str)) return
+    res = (str(i+1:i+1) == ch)
+  end function char_follows
+
+  ! True when str(i+1:i+1) exists and is an identifier character. Same
+  ! bounds-before-access split as char_follows.
+  function ident_char_follows(str, i) result(res)
+    character(len=*), intent(in) :: str
+    integer, intent(in) :: i
+    logical :: res
+    character :: c
+
+    res = .false.
+    if (i + 1 > len_trim(str)) return
+    c = str(i+1:i+1)
+    res = (c >= 'a' .and. c <= 'z') .or. (c >= 'A' .and. c <= 'Z') .or. &
+          (c >= '0' .and. c <= '9') .or. c == '_'
+  end function ident_char_follows
+
+  ! True when an unquoted <( or >( process substitution begins at str(i:i).
+  ! Checks run in separate statements because .and. does not short-circuit:
+  ! str(i+1:i+1) is out of bounds when i is the last character.
+  function procsub_starts_at(str, i, is_quoted) result(res)
+    character(len=*), intent(in) :: str
+    integer, intent(in) :: i
+    logical, intent(in) :: is_quoted
+    logical :: res
+
+    res = .false.
+    if (is_quoted) return
+    if (str(i:i) /= '<' .and. str(i:i) /= '>') return
+    if (i + 1 > len_trim(str)) return
+    res = (str(i+1:i+1) == '(')
+  end function procsub_starts_at
+
   ! Advance i from an opening quote at str(i:i) to just past its closing
   ! quote, so paren scans never see a ')' between quotes. Inside double
   ! quotes a backslash escapes the next character; single quotes are literal.
@@ -1506,7 +1551,7 @@ contains
           result(j:j+len_trim(pid_str)-1) = trim(pid_str)
           j = j + len_trim(pid_str)
           i = i + 1
-        else if (working_token(i:i) == '\' .and. i < len_trim(working_token) .and. working_token(i+1:i+1) == '!') then
+        else if (working_token(i:i) == '\' .and. char_follows(working_token, i, '!')) then
           ! Handle bash-escaped $\! (bash adds backslash before ! in some contexts)
           i = i + 1  ! Skip the backslash
           write(pid_str, '(i15)') shell%last_bg_pid
@@ -1558,8 +1603,7 @@ contains
           i = i + 1
         else if (working_token(i:i) == '_') then
           ! Check if this is $_ alone or $_varname
-          if (i+1 <= len_trim(working_token) .and. &
-              (is_alnum(working_token(i+1:i+1)) .or. working_token(i+1:i+1) == '_')) then
+          if (ident_char_follows(working_token, i)) then
             ! $_varname - underscore-prefixed variable name
             var_start = i
             do while (i <= len_trim(working_token) .and. &
@@ -1595,7 +1639,7 @@ contains
           i = i + 1
         else if (working_token(i:i) == '(') then
           ! Check if it's $(( arithmetic expansion or $( command substitution
-          if (i+1 <= len_trim(working_token) .and. working_token(i+1:i+1) == '(') then
+          if (char_follows(working_token, i, '(')) then
             ! $((arithmetic)) expansion
             var_start = i - 1  ! Include the $ character
             i = i + 2  ! Skip both opening parens
@@ -1755,9 +1799,7 @@ contains
       else if (working_token(i:i) == char(1)) then
         ! Skip sentinel character (marks quote boundary from lexer)
         i = i + 1
-      else if ((working_token(i:i) == '<' .or. working_token(i:i) == '>') .and. &
-               i + 1 <= len_trim(working_token) .and. working_token(i+1:i+1) == '(' .and. &
-               .not. is_quoted) then
+      else if (procsub_starts_at(working_token, i, is_quoted)) then
         ! Process substitution <(cmd) / >(cmd) — bash model:
         ! create pipe, fork child, use /dev/fd/N as the filename.
         ! No FIFOs, no temp files, no leaks.
@@ -2692,9 +2734,9 @@ contains
       end if
 
       ! Look for << not inside quotes (but NOT <<< which is here-string)
-      if (line(i:i) == '<' .and. i + 1 <= line_len .and. line(i+1:i+1) == '<') then
+      if (line(i:i) == '<' .and. char_follows(line, i, '<')) then
         ! Skip <<< (here-string, not heredoc)
-        if (i + 2 <= line_len .and. line(i+2:i+2) == '<') then
+        if (char_follows(line, i+1, '<')) then
           i = i + 3
           cycle
         end if

--- a/tests/builtins/test_ansic_nul.sh
+++ b/tests/builtins/test_ansic_nul.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# ANSI-C $'...' embedded NUL: bash drops everything from the NUL to the
+# closing quote but keeps adjacent segments of the same word. Before
+# PARSE-6 the standalone path embedded a raw NUL byte in the token and the
+# mid-word path silently dropped just the NUL — three-way disagreement.
+# The two paths also disagreed on high bytes (\xff worked standalone,
+# vanished mid-word); both now accept the full 0-255 range.
+TEST_PREFIX="[ansic-nul]"
+. "$(cd "$(dirname "$0")" && pwd)/test_harness.sh"
+
+section "1. NUL ends the \$'...' segment (both lexer paths)"
+
+compare_both "octal NUL standalone"      "printf '%s|' \$'a\\0b'"
+compare_both "octal NUL mid-word"        "printf '%s|' pre\$'a\\0b'"
+compare_both "hex NUL standalone"        "printf '%s|' \$'a\\x00b'"
+compare_both "hex NUL mid-word"          "printf '%s|' pre\$'a\\x00b'"
+compare_both "unicode NUL"               "printf '%s|' \$'a\\u0000b'"
+compare_both "bare NUL yields empty"     "printf '%s|' \$'\\0'"
+
+section "2. Adjacent segments of the word survive"
+
+compare_both "post segment kept"         "printf '%s|' \$'a\\0b'post"
+compare_both "pre and post kept"         "printf '%s|' pre\$'a\\0b'post"
+compare_both "escaped quote inside cut"  "printf '%s|' \$'a\\0b\\'c'"
+
+section "3. Non-NUL escapes agree between paths"
+
+compare_both "octal 1"                   "printf '%s|' \$'a\\1b'"
+compare_both "octal 101 is A"            "printf '%s|' \$'\\101'"
+compare_both "hex ff standalone"         "printf '%s|' \$'\\xff'"
+compare_both "hex ff mid-word"           "printf '%s|' pre\$'\\xff'"
+compare_both "octal 377 mid-word"        "printf '%s|' pre\$'\\377'"
+compare_both "newline escape"            "printf '%s|' \$'a\\nb'"
+compare_both "unknown escape kept"       "printf '%s|' \$'a\\qb'"
+
+print_summary

--- a/tests/builtins/test_cmdsubst_quotes.sh
+++ b/tests/builtins/test_cmdsubst_quotes.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# Quote-aware closing-paren scan for $(...) command substitution.
+# Before PARSE-2 the unquoted-word paren scan (and the expansion engine's
+# matching scan) counted every ')' including ones inside quotes, so
+# $(echo "a)b") ended at the quoted paren and the rest of the line was
+# re-lexed as word content — y=$(echo "p)q") assigned an empty value.
+TEST_PREFIX="[cmdsubst-quotes]"
+. "$(cd "$(dirname "$0")" && pwd)/test_harness.sh"
+
+section "1. Quoted ) inside unquoted \$()"
+
+compare_both "double-quoted ) survives" \
+    'echo $(echo "a)b")'
+compare_both "multiple quoted ) survive" \
+    'echo $(printf "%s" "1)2)3")'
+compare_both "single-quoted ) survives" \
+    "echo \$(echo 'a)b')"
+compare_both "quoted ( does not open a nesting level" \
+    'echo $(echo "unbalanced ( paren")'
+
+section "2. Assignment form (was silent data loss)"
+
+compare_both "assignment captures quoted )" \
+    'y=$(echo "p)q"); echo "[$y]"'
+compare_both "assignment captures single-quoted )" \
+    "y=\$(echo 'p)q'); echo \"[\$y]\""
+
+section "3. \$() inside double quotes agrees with unquoted form"
+
+compare_both "in-dquote substitution keeps quoted )" \
+    'echo "$(echo "a)b")"'
+compare_both "surrounding text preserved around quoted )" \
+    'echo "x$(echo "y)z")w"'
+
+section "4. Word continues after the substitution"
+
+compare_both "text after \$() stays in the same word" \
+    'echo pre$(echo "a)b")post'
+compare_both "two substitutions in one word" \
+    'echo $(echo "a)b")-$(echo "c)d")'
+
+section "5. Unaffected neighbors"
+
+compare_both "plain substitution" \
+    'echo $(echo hi)'
+compare_both "nested substitution without quotes" \
+    'echo $(echo $(echo deep))'
+compare_both "arithmetic expansion untouched" \
+    'echo $((1+2))'
+compare_both "backslash escape inside quoted span" \
+    'echo $(echo "a\)b")'
+
+# Known limit (matches the pre-existing in-double-quote path): a nested $( )
+# whose own double-quoted content contains ')' — e.g.
+#   echo $(echo "nested $(echo "x)y") ok")
+# needs recursive re-lexing of the inner substitution's quoting context.
+# Both scan paths now share one span-skipper, so they at least agree.
+
+print_summary

--- a/tests/builtins/test_empty_subshell_err.sh
+++ b/tests/builtins/test_empty_subshell_err.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Empty-subshell () syntax error format (PARSE-7). The non-interactive
+# prefix is deliberately "sh: -c: line 1:" (grammar_parser.f90 prefix
+# policy) so these cases assert the message shape, not bash's shell name:
+# both lines carry the full prefix including the line number, and the
+# second line echoes the offending input.
+TEST_PREFIX="[empty-subshell-err]"
+. "$(cd "$(dirname "$0")" && pwd)/test_harness.sh"
+
+section "1. Error format matches bash's shape"
+
+out=$(run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" -c '()' 2>&1)
+rc=$?
+line1=$(printf '%s\n' "$out" | sed -n 1p)
+line2=$(printf '%s\n' "$out" | sed -n 2p)
+if [ "$rc" -eq 2 ] && \
+   printf '%s' "$line1" | grep -q "line 1: syntax error near unexpected token \`)'" && \
+   printf '%s' "$line2" | grep -q "line 1: \`()'"; then
+    pass "() prints two fully-prefixed lines and exits 2"
+else
+    fail "() prints two fully-prefixed lines and exits 2" \
+         "line 1: on both lines, rc=2" "rc=$rc out=$out"
+fi
+
+compare_exit "exit status matches bash" '()'
+
+section "2. Non-empty subshell still parses"
+
+compare_both "simple subshell" '(echo ok)'
+compare_both "subshell exit status" '(exit 3); echo rc=$?'
+
+print_summary

--- a/tests/builtins/test_lexer_parser_bounds.sh
+++ b/tests/builtins/test_lexer_parser_bounds.sh
@@ -22,4 +22,38 @@ compare_both "process substitution still recognized" \
 compare_both "word ending in bare > is literal in quotes" \
     'echo "a>" "b<"'
 
+section "2. Two-byte \$'...' unknown-escape append at the buffer cap (MEM-1)"
+
+# The LEX_DOLLAR_SINGLE unknown-escape default writes two bytes; with only
+# a one-byte guard, a 4095-char pad put the second byte one past the 4096
+# buffer. Scripts are generated files because the -c buffer itself caps at
+# 4096 (PARSE-5). Word must START with $' — mid-word uses the other handler.
+for padlen in 4094 4095 4096; do
+    pad=$(awk -v n="$padlen" 'BEGIN{while(i++<n)printf "a"}')
+    scr="$TEST_TMPDIR/mem1_$padlen.sh"
+    printf "printf '%%s' \$'%s\\\\q'\n" "$pad" > "$scr"
+    out=$(run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" "$scr" 2>&1)
+    rc=$?
+    len=$(printf '%s' "$out" | wc -c)
+    if [ "$rc" -eq 0 ] && [ "$len" -le 4097 ] && \
+       ! printf '%s' "$out" | grep -qi 'runtime error'; then
+        pass "standalone \$'...' pad=$padlen survives \\q at the cap"
+    else
+        fail "standalone \$'...' pad=$padlen survives \\q at the cap" \
+             "rc=0, len<=4097, no runtime error" "rc=$rc len=$len"
+    fi
+done
+
+pad=$(awk 'BEGIN{while(i++<4095)printf "a"}')
+scr="$TEST_TMPDIR/mem1_midword.sh"
+printf "x=\$'%s\\\\q'\nprintf '%%s' \"\$x\" | wc -c\n" "$pad" > "$scr"
+out=$(run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" "$scr" 2>&1)
+rc=$?
+if [ "$rc" -eq 0 ] && ! printf '%s' "$out" | grep -qi 'runtime error'; then
+    pass "mid-word x=\$'...' pad=4095 survives \\q at the cap"
+else
+    fail "mid-word x=\$'...' pad=4095 survives \\q at the cap" \
+         "rc=0, no runtime error" "rc=$rc out=$(printf '%s' "$out" | head -c 60)"
+fi
+
 print_summary

--- a/tests/builtins/test_lexer_parser_bounds.sh
+++ b/tests/builtins/test_lexer_parser_bounds.sh
@@ -28,19 +28,23 @@ section "2. Two-byte \$'...' unknown-escape append at the buffer cap (MEM-1)"
 # a one-byte guard, a 4095-char pad put the second byte one past the 4096
 # buffer. Scripts are generated files because the -c buffer itself caps at
 # 4096 (PARSE-5). Word must START with $' — mid-word uses the other handler.
-for padlen in 4094 4095 4096; do
+# A pad at the cap either fits (rc 0) or is rejected with the MEM-5/PARSE-5
+# "word too long" diagnostic (rc 2). Either way it must not crash — under
+# -fcheck=bounds the original bug aborts with a Fortran runtime error.
+for padlen in 4093 4094 4095 4096; do
     pad=$(awk -v n="$padlen" 'BEGIN{while(i++<n)printf "a"}')
     scr="$TEST_TMPDIR/mem1_$padlen.sh"
     printf "printf '%%s' \$'%s\\\\q'\n" "$pad" > "$scr"
     out=$(run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" "$scr" 2>&1)
     rc=$?
-    len=$(printf '%s' "$out" | wc -c)
-    if [ "$rc" -eq 0 ] && [ "$len" -le 4097 ] && \
-       ! printf '%s' "$out" | grep -qi 'runtime error'; then
-        pass "standalone \$'...' pad=$padlen survives \\q at the cap"
+    if printf '%s' "$out" | grep -qi 'runtime error'; then
+        fail "standalone \$'...' pad=$padlen at the cap does not crash" \
+             "clean rc 0 or word-too-long rc 2" "runtime error: $(printf '%s' "$out" | head -c 80)"
+    elif [ "$rc" -eq 0 ] || { [ "$rc" -eq 2 ] && printf '%s' "$out" | grep -q 'word too long'; }; then
+        pass "standalone \$'...' pad=$padlen at the cap does not crash"
     else
-        fail "standalone \$'...' pad=$padlen survives \\q at the cap" \
-             "rc=0, len<=4097, no runtime error" "rc=$rc len=$len"
+        fail "standalone \$'...' pad=$padlen at the cap does not crash" \
+             "rc 0, or rc 2 + word-too-long" "rc=$rc out=$(printf '%s' "$out" | head -c 60)"
     fi
 done
 
@@ -49,11 +53,12 @@ scr="$TEST_TMPDIR/mem1_midword.sh"
 printf "x=\$'%s\\\\q'\nprintf '%%s' \"\$x\" | wc -c\n" "$pad" > "$scr"
 out=$(run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" "$scr" 2>&1)
 rc=$?
-if [ "$rc" -eq 0 ] && ! printf '%s' "$out" | grep -qi 'runtime error'; then
-    pass "mid-word x=\$'...' pad=4095 survives \\q at the cap"
+if ! printf '%s' "$out" | grep -qi 'runtime error' && \
+   { [ "$rc" -eq 0 ] || { [ "$rc" -eq 2 ] && printf '%s' "$out" | grep -q 'word too long'; }; }; then
+    pass "mid-word x=\$'...' pad=4095 at the cap does not crash"
 else
-    fail "mid-word x=\$'...' pad=4095 survives \\q at the cap" \
-         "rc=0, no runtime error" "rc=$rc out=$(printf '%s' "$out" | head -c 60)"
+    fail "mid-word x=\$'...' pad=4095 at the cap does not crash" \
+         "rc 0, or rc 2 + word-too-long" "rc=$rc out=$(printf '%s' "$out" | head -c 60)"
 fi
 
 print_summary

--- a/tests/builtins/test_lexer_parser_bounds.sh
+++ b/tests/builtins/test_lexer_parser_bounds.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Bounds-safety cases for the lexer/parser. Run against a `make debug`
+# build (-fcheck=bounds) these abort on any out-of-bounds substring access;
+# CI builds debug and runs this suite so a reintroduced OOB re-aborts.
+# On a release build they still assert behavior (exit codes, output).
+TEST_PREFIX="[lexer-parser-bounds]"
+. "$(cd "$(dirname "$0")" && pwd)/test_harness.sh"
+
+section "1. Redirect scan reads past end of exact-length token (DISC-2)"
+
+# expand_variables scanned working_token(i+1:i+1) unguarded while looking
+# for <( / >( — .and. does not short-circuit, so every redirect whose
+# filename filled its buffer aborted under -fcheck=bounds.
+compare_both "output redirect" \
+    'echo hi >/dev/null && echo ok'
+compare_both "input redirect" \
+    'cat </dev/null && echo ok'
+compare_both "append redirect" \
+    'echo hi >>/dev/null && echo ok'
+compare_both "process substitution still recognized" \
+    'cat < <(echo procsubst)'
+compare_both "word ending in bare > is literal in quotes" \
+    'echo "a>" "b<"'
+
+print_summary

--- a/tests/builtins/test_pipe_both.sh
+++ b/tests/builtins/test_pipe_both.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# |& pipes stdout+stderr (bash shorthand for 2>&1 |). Before PARSE-4 the
+# lexer split it into | plus a dangling &, which the parser rejected as a
+# syntax error.
+TEST_PREFIX="[pipe-both]"
+. "$(cd "$(dirname "$0")" && pwd)/test_harness.sh"
+
+section "1. |& routes stderr through the pipe"
+
+compare_both "stderr reaches the consumer" \
+    'ls /nonexistent-fortsh-test |& wc -l'
+compare_both "stdout still flows too" \
+    'echo visible |& cat'
+compare_both "merged streams stay ordered per stage" \
+    '{ echo out; ls /nonexistent-fortsh-test; } |& sort | head -2'
+
+section "2. Chaining and mixing with |"
+
+compare_both "chained |&" \
+    'echo a |& cat |& cat'
+compare_both "| then |&" \
+    'echo x | cat |& cat'
+compare_both "|& then |" \
+    'ls /nonexistent-fortsh-test |& cat | wc -l'
+
+section "3. Exit status comes from the last stage"
+
+compare_both "last stage failure" \
+    'true |& false; echo rc=$?'
+compare_both "last stage success" \
+    'ls /nonexistent-fortsh-test |& true; echo rc=$?'
+
+section "4. Bare | must not leak stderr into the pipe"
+
+compare_both "stderr bypasses a plain pipe" \
+    'ls /nonexistent-fortsh-test 2>/dev/null | wc -l'
+compare_both "explicit 2>&1 | equals |&" \
+    'ls /nonexistent-fortsh-test 2>&1 | wc -l'
+
+print_summary

--- a/tests/builtins/test_token_limits.sh
+++ b/tests/builtins/test_token_limits.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# PARSE-5 / MEM-5: no silent truncation at the lexer/parser capacity limits.
+# Token arrays and parser word lists grow past the initial 2000 entries; the
+# -c string is read at its full length; a single word over the fixed
+# 4096-byte token buffer is a loud syntax error (exit 2), never a silent clip.
+TEST_PREFIX="[token-limits]"
+. "$(cd "$(dirname "$0")" && pwd)/test_harness.sh"
+
+section "1. Token and word counts grow past 2000"
+
+many=$(seq 1 2100 | tr '\n' ' ')
+compare_both "2100-token pipeline keeps its final stage" \
+    "echo $many | wc -w"
+compare_both "3000-word for-loop list is complete" \
+    "for i in $(seq 1 3000 | tr '\n' ' '); do :; done; echo \$i"
+
+section "2. -c strings longer than 4096 bytes run in full"
+
+words=$(seq -f 'w%g' 1 900 | tr '\n' ' ')
+scr_cmd="echo $words>/dev/null; echo tail-ran"
+out=$(run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" -c "$scr_cmd" 2>&1)
+rc=$?
+if [ "$rc" -eq 0 ] && [ "$out" = "tail-ran" ]; then
+    pass "-c string of ${#scr_cmd} bytes executes its trailing command"
+else
+    fail "-c string of ${#scr_cmd} bytes executes its trailing command" \
+         "tail-ran (rc 0)" "rc=$rc out=$(printf '%s' "$out" | head -c 60)"
+fi
+
+section "3. Per-word 4096 cap: exact fit works, overflow is loud"
+
+w4096=$(awk 'BEGIN{while(i++<4096)printf "C"}')
+compare_both "4096-byte word passes byte-for-byte" \
+    "echo $w4096 | wc -c"
+
+w4097=$(awk 'BEGIN{while(i++<4097)printf "D"}')
+out=$(run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" -c "echo $w4097" 2>&1)
+rc=$?
+if [ "$rc" -eq 2 ] && printf '%s' "$out" | grep -q 'word too long'; then
+    pass "4097-byte word is rejected with a diagnostic, exit 2"
+else
+    fail "4097-byte word is rejected with a diagnostic, exit 2" \
+         "rc=2 + word too long" "rc=$rc out=$(printf '%s' "$out" | head -c 60)"
+fi
+
+out=$(printf 'echo %s\n' "$w4097" | run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" 2>&1)
+rc=$?
+if [ "$rc" -eq 2 ] && printf '%s' "$out" | grep -q 'word too long'; then
+    pass "over-long word via stdin is rejected too"
+else
+    fail "over-long word via stdin is rejected too" \
+         "rc=2 + word too long" "rc=$rc out=$(printf '%s' "$out" | head -c 60)"
+fi
+
+section "4. Ordinary input is unaffected"
+
+compare_both "small pipeline" 'echo hi | wc -w'
+compare_both "small for loop" 'for i in a b c; do echo $i; done'
+compare_both "4000-byte word round-trips" \
+    "echo $(awk 'BEGIN{while(i++<4000)printf "B"}') | wc -c"
+
+print_summary

--- a/tests/builtins/test_unterminated_eof.sh
+++ b/tests/builtins/test_unterminated_eof.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+# Unterminated quote / $( / ${ / $'...' at end of input must be a syntax
+# error (exit 2) in non-interactive mode. Before PARSE-3 the lexer flushed
+# the open construct as a completed word with no error flag, so fortsh ran
+# the mangled command and exited 0 (bash exits 2 with "unexpected EOF").
+TEST_PREFIX="[unterminated-eof]"
+. "$(cd "$(dirname "$0")" && pwd)/test_harness.sh"
+
+# The diagnostic prefix differs by design (fortsh: "sh: -c: line 1:", see
+# grammar_parser.f90 prefix policy / PARSE-7), so cases assert the exit
+# code plus the message body rather than diffing bash's full line.
+expect_eof_error() {
+    _name=$1; _cmd=$2; _closer=$3
+    _out=$(run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" -c "$_cmd" 2>&1)
+    _rc=$?
+    if [ "$_rc" -eq 2 ] && printf '%s' "$_out" | \
+         grep -q "unexpected EOF while looking for matching \`$_closer'"; then
+        pass "$_name"
+    else
+        fail "$_name" "rc=2 + EOF diagnostic naming $_closer" "rc=$_rc out=$_out"
+    fi
+}
+
+section "1. -c mode: exit 2 with the matching-closer diagnostic"
+
+expect_eof_error "unterminated double quote"  'echo "unterminated'   '"'
+expect_eof_error "unterminated single quote"  "echo 'unterminated"   "'"
+expect_eof_error "unterminated \$("           'echo $(echo hi'       ')'
+expect_eof_error "unterminated \${"           'echo ${unclosed'      '}'
+expect_eof_error "unterminated \$'...'"       "echo \$'abc"          "'"
+expect_eof_error "unterminated <("            'cat <(echo hi'        ')'
+expect_eof_error "mid-word \$'... "           "echo pre\$'abc"       "'"
+
+section "2. Exit code matches bash across the repros"
+
+compare_exit "double quote rc" 'echo "unterminated'
+compare_exit "single quote rc" "echo 'unterminated"
+compare_exit "\$( rc"          'echo $(echo hi'
+compare_exit "\${ rc"          'echo ${unclosed'
+
+section "3. Piped-stdin and script-file modes reject too"
+
+_out=$(printf 'echo "unterminated\n' | run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" 2>&1)
+_rc=$?
+if [ "$_rc" -eq 2 ] && printf '%s' "$_out" | grep -q 'unexpected EOF'; then
+    pass "stdin pipe exits 2 with diagnostic"
+else
+    fail "stdin pipe exits 2 with diagnostic" "rc=2 + EOF diagnostic" "rc=$_rc out=$_out"
+fi
+
+scr="$TEST_TMPDIR/unterm.sh"
+printf 'echo before\necho "unterminated\n' > "$scr"
+_out=$(run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" "$scr" 2>&1)
+_rc=$?
+if [ "$_rc" -eq 2 ] && printf '%s' "$_out" | grep -q '^before$' && \
+   printf '%s' "$_out" | grep -q 'unexpected EOF'; then
+    pass "script file runs prior lines then exits 2"
+else
+    fail "script file runs prior lines then exits 2" \
+         "before + diagnostic + rc=2" "rc=$_rc out=$_out"
+fi
+
+section "4. Terminated constructs and lookalikes still parse"
+
+compare_both "closed double quote"        'echo "ok"'
+compare_both "closed substitution"        'echo $(echo ok)'
+compare_both "closed parameter expansion" 'echo ${HOME:+ok}'
+compare_both "closed \$'...'"             "echo \$'ok'"
+compare_both "quote inside comment"       'echo ok # don"t care'
+compare_both "multiline quote in -c"      'echo "line one
+line two"'
+compare_both "heredoc body with quote"    'cat <<EOF
+it"s fine
+EOF'
+
+scr2="$TEST_TMPDIR/cont.sh"
+printf 'echo "line one\nline two"\necho done\n' > "$scr2"
+_out=$(run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" "$scr2" 2>&1)
+_rc=$?
+_exp=$(run_with_timeout "$TEST_TIMEOUT" "$BASH_REF" "$scr2" 2>&1)
+if [ "$_rc" -eq 0 ] && [ "$_out" = "$_exp" ]; then
+    pass "script-file quote continuation still joins lines"
+else
+    fail "script-file quote continuation still joins lines" "$_exp (rc 0)" "rc=$_rc out=$_out"
+fi
+
+print_summary


### PR DESCRIPTION
Fixes all eight Wave 2 findings from the 2026-07-13 adversarial audit, plus two discovered-issue cleanups. One finding per commit, each with a regression test; every fix verified against bash on the audit's repros.

## Findings resolved

- **PARSE-2** (H): the unquoted `$(…)` closing-paren scan ignored quotes — `y=$(echo "p)q")` silently assigned empty. Both the lexer scan and the expansion engine's sibling scan now share one quoted-span skipper.
- **MEM-1** (M): 2-byte OOB write in the `$'…'` unknown-escape handler at token_len 4095; guard now matches the correct sibling. Verified no abort under `-fcheck=bounds`.
- **PARSE-3** (M): unterminated `"`, `'`, `$'…'`, `$(`, `${`, `<(` at EOF were accepted silently (exit 0). Non-interactive modes now print bash's "unexpected EOF while looking for matching" diagnostic and exit 2; interactive continuation is unchanged. Script files no longer drop an unterminated trailing line.
- **PARSE-4** (M): `|&` now tokenizes and desugars to `2>&1 |` on the left stage, reusing the existing dup2 redirect path.
- **PARSE-5** (M): token array, parser word lists, and the `-c` buffer grow to fit — 2100-token pipelines keep their tail, 3000-word for-loops complete, `-c` strings of any length run in full.
- **MEM-5** (L): the per-word 4096-byte cap (fixed `token_t%%value`) is now loud: all 71 lexer append sites route through two shared helpers that flag overflow, and the parser rejects the input with "word too long" + exit 2 instead of silently clipping.
- **PARSE-6** (L): an escape resolving to NUL in `$'…'` now drops the rest of the segment (both lexer paths), matching bash byte-for-byte incl. adjacent-segment survival; also aligns the two paths' escape ranges (`\xff`/`\377` no longer vanish mid-word).
- **PARSE-7** (I): decision = keep the documented non-interactive `sh: -c: line 1:` prefix (POSIX suites byte-diff against reference `sh -c`). The empty-subshell echo line now carries the full prefix with the line segment and only prints non-interactively.

## Discovered issues

- **DISC-2** (fixed here): Fortran `.and.`/`.or.` don't short-circuit; lookahead substring reads in parser.f90, lexer.f90, and the heredoc preprocessor aborted any bounds-checked run. All routed through bounds-safe helpers. A new **Bounds-Checked Tests** CI job builds `make debug` and runs the new bounds suite so this class re-aborts in CI.
- **DISC-3** (logged): the wider codebase is not `-fcheck=bounds` clean (expansion.f90/executor.f90 sites, 172 builtin-test failures under debug). Tracked in discovered-issues.md for Wave 3+.

## Verification

- 960/0 builtin tests (70 new across 6 suites), 479/0 integration, POSIX quick at the known-green baseline (3630 passed, 2 pre-existing DOC-8 env-dependent failures).
- All wave-2 regression suites pass under `-fcheck=bounds`; remaining debug-only failures are the two documented DISC-3 sites outside this wave's files.

Stacked on #64 (wave 1). After #64 merges, retarget to trunk and close/reopen to trigger CI (the workflow only fires on trunk-based PRs).