### PR TITLE
Audit wave 4: test/[/[[ builtins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,10 +282,10 @@ $(BUILDDIR)/execution/command_capture.o: src/execution/command_capture.f90 $(BUI
 $(BUILDDIR)/execution/command_capture_callback.o: src/execution/command_capture_callback.f90 $(BUILDDIR)/common/types.o $(BUILDDIR)/parsing/grammar_parser.o $(BUILDDIR)/execution/ast_executor.o $(BUILDDIR)/parsing/command_tree.o $(BUILDDIR)/execution/command_capture.o | $(BUILDDIR)/execution
 	$(FC) $(FCFLAGS) -J$(BUILDDIR) -c $< -o $@
 
-$(BUILDDIR)/scripting/test_builtin.o: src/scripting/test_builtin.f90 $(BUILDDIR)/common/types.o $(BUILDDIR)/system/interface.o $(BUILDDIR)/scripting/variables.o $(BUILDDIR)/scripting/advanced_test.o | $(BUILDDIR)/scripting
+$(BUILDDIR)/scripting/test_builtin.o: src/scripting/test_builtin.f90 $(BUILDDIR)/common/types.o $(BUILDDIR)/system/interface.o $(BUILDDIR)/scripting/variables.o $(BUILDDIR)/scripting/advanced_test.o $(BUILDDIR)/common/io_helpers.o | $(BUILDDIR)/scripting
 	$(FC) $(FCFLAGS) -J$(BUILDDIR) -c $< -o $@
 
-$(BUILDDIR)/scripting/advanced_test.o: src/scripting/advanced_test.f90 $(BUILDDIR)/common/types.o $(BUILDDIR)/scripting/variables.o $(BUILDDIR)/system/interface.o | $(BUILDDIR)/scripting
+$(BUILDDIR)/scripting/advanced_test.o: src/scripting/advanced_test.f90 $(BUILDDIR)/common/types.o $(BUILDDIR)/scripting/variables.o $(BUILDDIR)/system/interface.o $(BUILDDIR)/common/io_helpers.o $(BUILDDIR)/scripting/expansion.o | $(BUILDDIR)/scripting
 	$(FC) $(FCFLAGS) -J$(BUILDDIR) -c $< -o $@
 
 $(BUILDDIR)/scripting/printf_builtin.o: src/scripting/printf_builtin.f90 $(BUILDDIR)/common/types.o | $(BUILDDIR)/scripting

--- a/src/common/io_helpers.f90
+++ b/src/common/io_helpers.f90
@@ -34,6 +34,7 @@ module io_helpers
   public :: write_stdout, write_stderr, write_stdout_nonl
   public :: write_stdout_checked, write_stdout_nonl_checked
   public :: write_error_message
+  public :: parse_int64
 
 contains
 
@@ -157,5 +158,31 @@ contains
 
     deallocate(c_str)
   end subroutine write_stderr
+
+  ! Parse a decimal integer (optional sign, surrounding blanks) into int64.
+  ! ok is .false. for anything else — callers must not treat garbage as 0.
+  ! Shared by test/[ (BUILTIN-5/6) and printf (wave-5 64-bit work) so
+  ! integer parsing and overflow behavior stay consistent across builtins.
+  subroutine parse_int64(str, value, ok)
+    use iso_fortran_env, only: int64
+    character(len=*), intent(in) :: str
+    integer(int64), intent(out) :: value
+    logical, intent(out) :: ok
+    character(len=:), allocatable :: t
+    integer :: k, s, ios
+
+    value = 0_int64
+    ok = .false.
+    t = trim(adjustl(str))
+    if (len(t) == 0) return
+    s = 1
+    if (t(1:1) == '+' .or. t(1:1) == '-') s = 2
+    if (s > len(t)) return
+    do k = s, len(t)
+      if (t(k:k) < '0' .or. t(k:k) > '9') return
+    end do
+    read(t, *, iostat=ios) value
+    ok = (ios == 0)
+  end subroutine parse_int64
 
 end module io_helpers

--- a/src/execution/pipeline_helpers.f90
+++ b/src/execution/pipeline_helpers.f90
@@ -118,6 +118,7 @@ contains
     temp_cap = max(cmd%num_tokens * 10, 256)
     allocate(temp_tokens(temp_cap))
     allocate(temp_token_lengths(temp_cap))
+
     allocate(temp_token_quoted(temp_cap))
     temp_token_lengths = 0
     temp_token_quoted = .false.
@@ -818,22 +819,44 @@ contains
       end do
       cmd%num_tokens = expanded_count
 
-      ! Update token_lengths to match new tokens (use trimmed length)
-      if (allocated(cmd%token_lengths)) deallocate(cmd%token_lengths)
-      allocate(cmd%token_lengths(expanded_count))
-      do i = 1, expanded_count
-        cmd%token_lengths(i) = len_trim(expanded_tokens(i))
-      end do
+      ! Rebuild token metadata. Globbing only rewrites tokens it expands;
+      ! when the count is unchanged, tokens that passed through verbatim
+      ! keep their original length and quoted/escaped flags — resetting
+      ! them dropped trailing spaces of quoted operands whenever a sibling
+      ! token merely CONTAINED a glob character ([ "x " = "x" ]).
+      block
+        integer, allocatable :: old_lens(:)
+        logical, allocatable :: old_q(:), old_e(:)
+        integer :: old_num
 
-      ! Reset token_quoted and token_escaped for expanded tokens
-      ! (glob-expanded filenames are not quoted)
-      if (allocated(cmd%token_quoted)) deallocate(cmd%token_quoted)
-      allocate(cmd%token_quoted(expanded_count))
-      cmd%token_quoted = .false.
-
-      if (allocated(cmd%token_escaped)) deallocate(cmd%token_escaped)
-      allocate(cmd%token_escaped(expanded_count))
-      cmd%token_escaped = .false.
+        old_num = size(original_tokens)
+        if (allocated(cmd%token_lengths)) call move_alloc(cmd%token_lengths, old_lens)
+        if (allocated(cmd%token_quoted)) call move_alloc(cmd%token_quoted, old_q)
+        if (allocated(cmd%token_escaped)) call move_alloc(cmd%token_escaped, old_e)
+        allocate(cmd%token_lengths(expanded_count))
+        allocate(cmd%token_quoted(expanded_count))
+        allocate(cmd%token_escaped(expanded_count))
+        do i = 1, expanded_count
+          cmd%token_lengths(i) = len_trim(expanded_tokens(i))
+          cmd%token_quoted(i) = .false.
+          cmd%token_escaped(i) = .false.
+          if (expanded_count == old_num) then
+            if (expanded_tokens(i) == original_tokens(i)) then
+              if (allocated(old_lens)) then
+                if (i <= size(old_lens)) then
+                  if (old_lens(i) > cmd%token_lengths(i)) cmd%token_lengths(i) = old_lens(i)
+                end if
+              end if
+              if (allocated(old_q)) then
+                if (i <= size(old_q)) cmd%token_quoted(i) = old_q(i)
+              end if
+              if (allocated(old_e)) then
+                if (i <= size(old_e)) cmd%token_escaped(i) = old_e(i)
+              end if
+            end if
+          end if
+        end do
+      end block
     else
       ! No expansion occurred - restore original
       allocate(character(len=tok_char_len) :: cmd%tokens(cmd%num_tokens))

--- a/src/scripting/advanced_test.f90
+++ b/src/scripting/advanced_test.f90
@@ -72,7 +72,7 @@ module advanced_test
 contains
 
   ! Main [[ ]] test evaluation
-  function evaluate_test_expression(shell, tokens, num_tokens) result(test_result)
+  recursive function evaluate_test_expression(shell, tokens, num_tokens) result(test_result)
     type(shell_state_t), intent(inout) :: shell
     character(len=*), intent(in) :: tokens(:)
     integer, intent(in) :: num_tokens
@@ -86,6 +86,29 @@ contains
     if (num_tokens < 3) then
       test_result = TEST_ERROR
       return
+    end if
+
+    ! A leading ! negates the whole expression. Handle it before the
+    ! token-count dispatch below, which would otherwise route
+    ! [[ ! -e x ]] (5 tokens) into the binary branch with left='!'.
+    if (num_tokens >= 4) then
+      if (trim(tokens(2)) == '!') then
+        block
+          character(len=len(tokens)) :: sub_tokens(num_tokens - 1)
+          integer :: si
+          sub_tokens(1) = tokens(1)
+          do si = 3, num_tokens
+            sub_tokens(si - 1) = tokens(si)
+          end do
+          test_result = evaluate_test_expression(shell, sub_tokens, num_tokens - 1)
+          if (test_result == TEST_TRUE) then
+            test_result = TEST_FALSE
+          else if (test_result == TEST_FALSE) then
+            test_result = TEST_TRUE
+          end if
+        end block
+        return
+      end if
     end if
 
     ! Skip [[ and ]] tokens
@@ -146,7 +169,8 @@ contains
     case ('=', '==')
       result_bool = wildcard_match(trim(expanded_left), trim(expanded_right))
     case ('!=')
-      result_bool = (trim(expanded_left) /= trim(expanded_right))
+      ! != negates the pattern match, mirroring == (the RHS is a glob)
+      result_bool = .not. wildcard_match(trim(expanded_left), trim(expanded_right))
     case ('<')
       result_bool = (trim(expanded_left) < trim(expanded_right))
     case ('>')
@@ -158,17 +182,17 @@ contains
     
     ! Numeric comparisons
     case ('-eq')
-      result_bool = numeric_equal(expanded_left, expanded_right)
+      result_bool = numeric_compare(shell, expanded_left, expanded_right, 'eq')
     case ('-ne')
-      result_bool = .not. numeric_equal(expanded_left, expanded_right)
+      result_bool = numeric_compare(shell, expanded_left, expanded_right, 'ne')
     case ('-lt')
-      result_bool = numeric_less_than(expanded_left, expanded_right)
+      result_bool = numeric_compare(shell, expanded_left, expanded_right, 'lt')
     case ('-le')
-      result_bool = numeric_less_equal(expanded_left, expanded_right)
+      result_bool = numeric_compare(shell, expanded_left, expanded_right, 'le')
     case ('-gt')
-      result_bool = numeric_greater_than(expanded_left, expanded_right)
+      result_bool = numeric_compare(shell, expanded_left, expanded_right, 'gt')
     case ('-ge')
-      result_bool = numeric_greater_equal(expanded_left, expanded_right)
+      result_bool = numeric_compare(shell, expanded_left, expanded_right, 'ge')
     
     ! File tests
     case ('-ef')
@@ -412,6 +436,38 @@ contains
         end do
         
         return
+      else if (pattern(p_pos:p_pos) == '[') then
+        ! Bracket expression: [abc], [a-z], leading ! or ^ negates
+        block
+          integer :: close_pos, ci
+          logical :: negated, member
+          close_pos = 0
+          ci = p_pos + 1
+          if (ci <= p_len) then
+            if (pattern(ci:ci) == '!' .or. pattern(ci:ci) == '^') ci = ci + 1
+          end if
+          ci = ci + 1  ! a ] right after the (negated) opening is a literal member
+          do while (ci <= p_len)
+            if (pattern(ci:ci) == ']') then
+              close_pos = ci
+              exit
+            end if
+            ci = ci + 1
+          end do
+          if (close_pos == 0) then
+            ! No closing ] — a lone [ matches itself, like bash
+            if (pattern(p_pos:p_pos) /= string(s_pos:s_pos)) return
+            p_pos = p_pos + 1
+            s_pos = s_pos + 1
+          else
+            member = char_in_bracket(string(s_pos:s_pos), &
+                                     pattern(p_pos+1:close_pos-1), negated)
+            if (negated) member = .not. member
+            if (.not. member) return
+            p_pos = close_pos + 1
+            s_pos = s_pos + 1
+          end if
+        end block
       else if (pattern(p_pos:p_pos) == '?' .or. pattern(p_pos:p_pos) == string(s_pos:s_pos)) then
         p_pos = p_pos + 1
         s_pos = s_pos + 1
@@ -428,81 +484,78 @@ contains
     matches = (s_pos > s_len .and. p_pos > p_len)
   end function
 
+  ! Test one character against a bracket-expression body (content between
+  ! [ and ]). Handles literal sets, a-z ranges, and a leading !/^ which is
+  ! reported through `negated` for the caller to apply.
+  function char_in_bracket(c, body, negated) result(member)
+    character, intent(in) :: c
+    character(len=*), intent(in) :: body
+    logical, intent(out) :: negated
+    logical :: member
+    integer :: k, blen
+
+    member = .false.
+    negated = .false.
+    blen = len(body)
+    k = 1
+    if (blen >= 1) then
+      if (body(1:1) == '!' .or. body(1:1) == '^') then
+        negated = .true.
+        k = 2
+      end if
+    end if
+    do while (k <= blen)
+      ! Bounds check split from the read: .and. does not short-circuit
+      if (k + 2 <= blen) then
+        if (body(k+1:k+1) == '-') then
+          ! Range a-z
+          if (c >= body(k:k) .and. c <= body(k+2:k+2)) member = .true.
+          k = k + 3
+          cycle
+        end if
+      end if
+      if (c == body(k:k)) member = .true.
+      k = k + 1
+    end do
+  end function char_in_bracket
+
   ! Numeric comparison functions
-  function numeric_equal(left, right) result(equal)
-    character(len=*), intent(in) :: left, right
-    logical :: equal
-    integer :: left_val, right_val, status1, status2
-    
-    read(left, *, iostat=status1) left_val
-    read(right, *, iostat=status2) right_val
-    
-    if (status1 == 0 .and. status2 == 0) then
-      equal = (left_val == right_val)
-    else
-      equal = .false.
-    end if
-  end function
+  ! [[ ]] numeric operands are arithmetic expressions: bare names resolve
+  ! as variables and expressions evaluate (BUILTIN-13), 64-bit so values
+  ! past 2^31 compare correctly (BUILTIN-6).
+  function numeric_operand(shell, operand, val) result(ok)
+    use expansion, only: arithmetic_expansion_shell
+    use io_helpers, only: parse_int64
+    use iso_fortran_env, only: int64
+    type(shell_state_t), intent(inout) :: shell
+    character(len=*), intent(in) :: operand
+    integer(int64), intent(out) :: val
+    logical :: ok
+    character(len=32) :: astr
 
-  function numeric_less_than(left, right) result(less)
-    character(len=*), intent(in) :: left, right
-    logical :: less
-    integer :: left_val, right_val, status1, status2
-    
-    read(left, *, iostat=status1) left_val
-    read(right, *, iostat=status2) right_val
-    
-    if (status1 == 0 .and. status2 == 0) then
-      less = (left_val < right_val)
-    else
-      less = .false.
-    end if
-  end function
+    astr = arithmetic_expansion_shell('$((' // trim(operand) // '))', shell)
+    call parse_int64(astr, val, ok)
+  end function numeric_operand
 
-  function numeric_less_equal(left, right) result(less_eq)
-    character(len=*), intent(in) :: left, right
-    logical :: less_eq
-    integer :: left_val, right_val, status1, status2
-    
-    read(left, *, iostat=status1) left_val
-    read(right, *, iostat=status2) right_val
-    
-    if (status1 == 0 .and. status2 == 0) then
-      less_eq = (left_val <= right_val)
-    else
-      less_eq = .false.
-    end if
-  end function
+  function numeric_compare(shell, left, right, op) result(res)
+    use iso_fortran_env, only: int64
+    type(shell_state_t), intent(inout) :: shell
+    character(len=*), intent(in) :: left, right, op
+    logical :: res
+    integer(int64) :: lv, rv
 
-  function numeric_greater_than(left, right) result(greater)
-    character(len=*), intent(in) :: left, right
-    logical :: greater
-    integer :: left_val, right_val, status1, status2
-    
-    read(left, *, iostat=status1) left_val
-    read(right, *, iostat=status2) right_val
-    
-    if (status1 == 0 .and. status2 == 0) then
-      greater = (left_val > right_val)
-    else
-      greater = .false.
-    end if
-  end function
-
-  function numeric_greater_equal(left, right) result(greater_eq)
-    character(len=*), intent(in) :: left, right
-    logical :: greater_eq
-    integer :: left_val, right_val, status1, status2
-    
-    read(left, *, iostat=status1) left_val
-    read(right, *, iostat=status2) right_val
-    
-    if (status1 == 0 .and. status2 == 0) then
-      greater_eq = (left_val >= right_val)
-    else
-      greater_eq = .false.
-    end if
-  end function
+    res = .false.
+    if (.not. numeric_operand(shell, left, lv)) return
+    if (.not. numeric_operand(shell, right, rv)) return
+    select case(op)
+    case('eq'); res = (lv == rv)
+    case('ne'); res = (lv /= rv)
+    case('lt'); res = (lv < rv)
+    case('le'); res = (lv <= rv)
+    case('gt'); res = (lv > rv)
+    case('ge'); res = (lv >= rv)
+    end select
+  end function numeric_compare
 
   ! File comparison functions (simplified implementations)
   function files_same_device_inode(file1, file2) result(same)

--- a/src/scripting/test_builtin.f90
+++ b/src/scripting/test_builtin.f90
@@ -7,7 +7,8 @@ module test_builtin
   use system_interface
   use variables, only: is_shell_variable_set
   use advanced_test, only: evaluate_test_expression
-  use iso_fortran_env, only: output_unit, error_unit
+  use iso_fortran_env, only: output_unit, error_unit, int64
+  use io_helpers, only: parse_int64
   implicit none
 
 contains
@@ -192,29 +193,46 @@ contains
         right_operand = cmd%tokens(4)
 
         select case(trim(operator))
-      ! String comparisons
+      ! String comparisons — true token lengths, so trailing spaces
+      ! are significant ("x " differs from "x")
       case('=', '==')
-        test_result = (trim(left_operand) == trim(right_operand))
+        test_result = tokens_str_equal(cmd, 2, 4)
       case('!=')
-        test_result = (trim(left_operand) /= trim(right_operand))
+        test_result = .not. tokens_str_equal(cmd, 2, 4)
       case('<')
         test_result = (trim(left_operand) < trim(right_operand))
       case('>')
         test_result = (trim(left_operand) > trim(right_operand))
 
-      ! Integer comparisons
-      case('-eq')
-        test_result = string_to_int(left_operand) == string_to_int(right_operand)
-      case('-ne')
-        test_result = string_to_int(left_operand) /= string_to_int(right_operand)
-      case('-lt')
-        test_result = string_to_int(left_operand) < string_to_int(right_operand)
-      case('-le')
-        test_result = string_to_int(left_operand) <= string_to_int(right_operand)
-      case('-gt')
-        test_result = string_to_int(left_operand) > string_to_int(right_operand)
-      case('-ge')
-        test_result = string_to_int(left_operand) >= string_to_int(right_operand)
+      ! Integer comparisons: 64-bit, and a non-integer operand is a
+      ! usage error (exit 2), never silently 0
+      case('-eq', '-ne', '-lt', '-le', '-gt', '-ge')
+        block
+          integer(int64) :: lv, rv
+          logical :: lok, rok
+          call parse_int64(left_operand, lv, lok)
+          call parse_int64(right_operand, rv, rok)
+          if (.not. lok) then
+            write(error_unit, '(a)') 'fortsh: [: ' // trim(left_operand) // &
+                                     ': integer expression expected'
+            shell%last_exit_status = 2
+            return
+          end if
+          if (.not. rok) then
+            write(error_unit, '(a)') 'fortsh: [: ' // trim(right_operand) // &
+                                     ': integer expression expected'
+            shell%last_exit_status = 2
+            return
+          end if
+          select case(trim(operator))
+          case('-eq'); test_result = (lv == rv)
+          case('-ne'); test_result = (lv /= rv)
+          case('-lt'); test_result = (lv < rv)
+          case('-le'); test_result = (lv <= rv)
+          case('-gt'); test_result = (lv > rv)
+          case('-ge'); test_result = (lv >= rv)
+          end select
+        end block
 
       ! File comparisons
       case('-nt')
@@ -365,13 +383,31 @@ contains
     end if
   end subroutine
 
-  function string_to_int(str) result(int_val)
-    character(len=*), intent(in) :: str
-    integer :: int_val
-    integer :: iostat
-    
-    read(str, *, iostat=iostat) int_val
-    if (iostat /= 0) int_val = 0
-  end function
+  ! True content length of a token: token_lengths preserves trailing
+  ! spaces of quoted operands that trim() would drop.
+  function token_len_of(cmd, idx) result(l)
+    type(command_t), intent(in) :: cmd
+    integer, intent(in) :: idx
+    integer :: l
+
+    l = len_trim(cmd%tokens(idx))
+    if (allocated(cmd%token_lengths)) then
+      if (idx <= size(cmd%token_lengths)) then
+        if (cmd%token_lengths(idx) > l) l = cmd%token_lengths(idx)
+      end if
+    end if
+  end function token_len_of
+
+  function tokens_str_equal(cmd, li, ri) result(eq)
+    type(command_t), intent(in) :: cmd
+    integer, intent(in) :: li, ri
+    logical :: eq
+    integer :: ll, rl
+
+    ll = token_len_of(cmd, li)
+    rl = token_len_of(cmd, ri)
+    eq = .false.
+    if (ll == rl) eq = (cmd%tokens(li)(1:ll) == cmd%tokens(ri)(1:rl))
+  end function tokens_str_equal
 
 end module test_builtin

--- a/tests/builtins/test_test.sh
+++ b/tests/builtins/test_test.sh
@@ -93,4 +93,23 @@ compare_exit "[ 11-digit value ]"      '[ 99999999999 -gt 5 ]'
 compare_exit "[[ 5000000000 -gt 4 ]]"  '[[ 5000000000 -gt 4 ]]'
 compare_exit "[ 2147483647 still ok ]" '[ 2147483647 -gt 5 ]'
 
+section "10. Wave-4: [[ ]] negation, patterns, arithmetic (BUILTIN-3/7/12/13)"
+
+compare_exit "[[ ! -e missing ]]"       '[[ ! -e /nonexistent ]]'
+compare_exit "[[ ! -f missing ]]"       '[[ ! -f /nonexistent ]]'
+compare_exit "[[ ! -d missing ]]"       '[[ ! -d /nonexistent ]]'
+compare_exit "[[ ! -z nonempty ]]"      '[[ ! -z foo ]]'
+compare_exit "[[ ! -e / ]] is false"    '[[ ! -e / ]]'
+compare_exit "[[ != negates glob ]]"    '[[ abc != a* ]]'
+compare_exit "[[ != non-matching ]]"    '[[ abc != x* ]]'
+compare_exit "[[ == glob unchanged ]]"  '[[ abc == a* ]]'
+compare_exit "[[ bracket class hit ]]"  '[[ x == [xy] ]]'
+compare_exit "[[ bracket class miss ]]" '[[ z == [xy] ]]'
+compare_exit "[[ range class ]]"        '[[ m == [a-z] ]]'
+compare_exit "[[ range class miss ]]"   '[[ 5 == [a-z] ]]'
+compare_exit "[[ negated class ]]"      '[[ a == [!b] ]]'
+compare_exit "[[ arithmetic operand ]]" '[[ "2+2" -eq 4 ]]'
+compare_exit "[[ bare name operand ]]"  'x=5; [[ x -eq 5 ]]'
+compare_exit "[[ expanded still ok ]]"  'x=5; [[ $x -eq 5 ]]'
+
 print_summary

--- a/tests/builtins/test_test.sh
+++ b/tests/builtins/test_test.sh
@@ -65,4 +65,32 @@ compare_exit "[[ string comparison > ]]" '[[ "def" > "abc" ]]'
 compare_exit "[[ -z in extended ]]" '[[ -z "" ]]'
 compare_exit "[[ -n in extended ]]" '[[ -n "hello" ]]'
 
+section "7. Wave-4: string compares honor trailing spaces (BUILTIN-4)"
+
+compare_exit "[ trailing space differs ]"    '[ "x " = "x" ]'
+compare_exit "[ blank differs from empty ]"  '[ " " = "" ]'
+compare_exit "[ != sees trailing space ]"    '[ "x " != "x" ]'
+compare_exit "[ equal stays equal ]"         '[ "x" = "x" ]'
+compare_exit "test trailing space differs"   'test "x " = "x"'
+
+section "8. Wave-4: non-integer operands are usage errors (BUILTIN-5)"
+
+compare_exit "[ abc -eq 1 ] exits 2"   '[ abc -eq 1 ]'
+compare_exit "[ abc -eq 0 ] exits 2"   '[ abc -eq 0 ]'
+compare_exit "[ 5 -gt abc ] exits 2"   '[ 5 -gt abc ]'
+compare_exit "valid compare unchanged" '[ 5 -gt 3 ]'
+out=$(run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" -c '[ abc -eq 1 ]' 2>&1)
+if printf '%s' "$out" | grep -q 'integer expression expected'; then
+    pass "diagnostic names the bad operand"
+else
+    fail "diagnostic names the bad operand" "integer expression expected" "$out"
+fi
+
+section "9. Wave-4: 64-bit numeric comparisons (BUILTIN-6)"
+
+compare_exit "[ 2^31 boundary ]"       '[ 2147483648 -gt 5 ]'
+compare_exit "[ 11-digit value ]"      '[ 99999999999 -gt 5 ]'
+compare_exit "[[ 5000000000 -gt 4 ]]"  '[[ 5000000000 -gt 4 ]]'
+compare_exit "[ 2147483647 still ok ]" '[ 2147483647 -gt 5 ]'
+
 print_summary


### PR DESCRIPTION
Fixes all seven Wave 4 findings — the test/[/[[ defects that silently invert script control flow. Verified against bash on every repro; 30 new regression cases in test_test.sh.

## Findings resolved

- **BUILTIN-3** (H): `[[ ! -e x ]]` is 5 tokens and routed into the binary branch with left=`!`, silently dropping the negation. A leading `!` now strips and inverts recursively before the count dispatch.
- **BUILTIN-4** (H): `[ "x " = "x" ]` compared trim()ed operands. String compares use true token lengths now. The root enabler was upstream: `expand_command_globs` rebuilt the token array (resetting every length and quoted flag) for any command merely *containing* a glob character — which `[` and `]` are. Pass-through tokens keep their metadata.
- **BUILTIN-5** (H): non-integer `-eq` operands silently became 0 (`[ abc -eq 0 ]` was TRUE). Now "integer expression expected" on stderr and exit 2.
- **BUILTIN-7** (H): `[[ abc != a* ]]` did plain string inequality; `!=` now negates the glob match, mirroring `==`.
- **BUILTIN-6** (H): comparisons were 32-bit; now int64 in both `[`/`test` and `[[ ]]`, via a shared `parse_int64` in io_helpers that wave 5's printf work will reuse.
- **BUILTIN-12** (M): `wildcard_match` gained bracket expressions — literal sets, `a-z` ranges, `[!...]` negation.
- **BUILTIN-13** (L): `[[ ]]` numeric operands evaluate through the `$(( ))` evaluator, so `[[ "2+2" -eq 4 ]]` and bare variable names work.

## Verification

- 1088/0 builtin tests, 479/0 integration, POSIX quick at the known-green baseline.
- Campaign standing: 46 of 85 findings resolved (waves 0-4).

Stacked on #66 (wave 3). Merge train: #65 → #66 → this.