### PR TITLE
Audit wave 6: builtins & command resolution

### DIFF
--- a/src/scripting/command_builtin.f90
+++ b/src/scripting/command_builtin.f90
@@ -480,7 +480,7 @@ contains
     character(len=*), intent(in) :: command_name
     logical :: is_builtin
     
-    character(len=16), parameter :: builtins(56) = [ &
+    character(len=16), parameter :: builtins(62) = [ &
       'cd              ', 'pwd             ', 'echo            ', 'printf          ', &
       'read            ', 'export          ', 'unset           ', 'set             ', &
       'shift           ', 'test            ', 'true            ', 'false           ', &
@@ -494,7 +494,9 @@ contains
       'help            ', 'defun           ', 'abbr            ', 'which           ', &
       'history         ', 'shopt           ', 'complete        ', 'compgen         ', &
       'coproc          ', 'printenv        ', 'pushd           ', 'popd            ', &
-      'dirs            ', 'prevd           ', 'nextd           ', 'dirh            ' ]
+      'dirs            ', 'prevd           ', 'nextd           ', 'dirh            ', &
+      ':               ', 'config          ', 'memory          ', 'perf            ', &
+      'disown          ', 'rawtest         ' ]
     
     integer :: i
     

--- a/src/scripting/config.f90
+++ b/src/scripting/config.f90
@@ -441,24 +441,27 @@ contains
       return
     end if
     
-    ! Construct config file path
-    config_file = trim(home_dir) // '/.fshrc'
-    
-    ! Check if config file exists
+    ! Prefer the documented ~/.fortshrc; fall back to the legacy ~/.fshrc,
+    ! mirroring the startup source order (DOC-10)
+    config_file = trim(home_dir) // '/.fortshrc'
     inquire(file=config_file, exist=file_exists)
     if (.not. file_exists) then
-      write(output_unit, '(a)') 'fortsh: no .fshrc file found'
+      config_file = trim(home_dir) // '/.fshrc'
+      inquire(file=config_file, exist=file_exists)
+    end if
+    if (.not. file_exists) then
+      write(output_unit, '(a)') 'fortsh: no .fortshrc file found'
       return
     end if
     
     ! Open and display the config file
     open(newunit=unit, file=config_file, status='old', action='read', iostat=iostat)
     if (iostat /= 0) then
-      write(error_unit, '(a)') 'fortsh: error: could not read .fshrc'
+      write(error_unit, '(a)') 'fortsh: error: could not read ' // trim(config_file)
       return
     end if
     
-    write(output_unit, '(a)') 'Contents of .fshrc:'
+    write(output_unit, '(a)') 'Contents of ' // trim(config_file) // ':'
     write(output_unit, '(a)') '=================='
     
     do

--- a/src/scripting/getopts_builtin.f90
+++ b/src/scripting/getopts_builtin.f90
@@ -155,6 +155,9 @@ contains
       call set_shell_variable(shell, trim(optname), '?')
       if (silent_mode) then
         call set_shell_variable(shell, 'OPTARG', opt_char)
+      else
+        ! Non-silent mode prints the diagnostic, like bash (BUILTIN-18)
+        write(error_unit, '(a)') 'fortsh: illegal option -- ' // opt_char
       end if
       
       if (current_pos > len_trim(current_arg)) then

--- a/src/scripting/shell_options.f90
+++ b/src/scripting/shell_options.f90
@@ -53,6 +53,7 @@ contains
     character(len=256) :: option_str, option_name, param_idx_str
     integer :: i, arg_len, param_idx
     logical :: enable_option, setting_positional
+    logical :: set_failed
 
     if (cmd%num_tokens == 1) then
       ! Show all variables (simplified)
@@ -61,6 +62,7 @@ contains
     end if
 
     setting_positional = .false.
+    set_failed = .false.
     i = 2
     do while (i <= cmd%num_tokens)
       option_str = trim(cmd%tokens(i))
@@ -226,13 +228,16 @@ contains
                   shell%option_xtrace = enable_option
                 case default
                   write(error_unit, '(a)') 'set: unknown option: ' // trim(long_opt_name)
-                  shell%last_exit_status = 1
+                  ! bash: invalid option name exits 2
+                  shell%last_exit_status = 2
+                  set_failed = .true.
               end select
             end if
           case default
             write(error_unit, '(a)') 'set: unknown option: -' // option_name(fi:fi)
             had_error = .true.
-            shell%last_exit_status = 1
+            shell%last_exit_status = 2
+            set_failed = .true.
           end select
           fi = fi + 1
         end do
@@ -242,7 +247,8 @@ contains
       i = i + 1
     end do
     
-    shell%last_exit_status = 0
+    ! Keep the error status a failed option set above (BUILTIN-14)
+    if (.not. set_failed) shell%last_exit_status = 0
   end subroutine
 
   ! Handle 'shopt' builtin command for bash-style options
@@ -253,6 +259,9 @@ contains
     character(len=256) :: option_name, flag
     integer :: i
     logical :: show_all = .false., enable_option = .true.
+    logical :: shopt_failed, opt_ok
+
+    shopt_failed = .false.
     
     if (cmd%num_tokens == 1) then
       show_all = .true.
@@ -270,7 +279,8 @@ contains
         show_all = .true.
       else
         option_name = trim(flag)
-        call set_shopt_option(shell, option_name, enable_option)
+        call set_shopt_option(shell, option_name, enable_option, opt_ok)
+        if (.not. opt_ok) shopt_failed = .true.
       end if
       
       i = i + 1
@@ -280,15 +290,18 @@ contains
       call show_shopt_options(shell)
     end if
     
-    shell%last_exit_status = 0
+    ! Keep the error status a failed option set above (BUILTIN-14)
+    if (.not. shopt_failed) shell%last_exit_status = 0
   end subroutine
 
   ! Set a shopt option
-  subroutine set_shopt_option(shell, option_name, enable)
+  subroutine set_shopt_option(shell, option_name, enable, ok)
     type(shell_state_t), intent(inout) :: shell
     character(len=*), intent(in) :: option_name
     logical, intent(in) :: enable
-    
+    logical, intent(out), optional :: ok
+
+    if (present(ok)) ok = .true.
     select case (trim(option_name))
       case ('nullglob')
         shell%shopt_nullglob = enable
@@ -309,6 +322,7 @@ contains
       case default
         write(error_unit, '(a)') 'shopt: unknown option: ' // trim(option_name)
         shell%last_exit_status = 1
+        if (present(ok)) ok = .false.
     end select
   end subroutine
 

--- a/tests/builtins/test_config.sh
+++ b/tests/builtins/test_config.sh
@@ -9,4 +9,24 @@ check_exit "config with no args shows config" 'config' "0"
 section "2. config operations"
 check_exit "config reload" 'config reload 2>/dev/null; true' "0"
 
+section "9. Wave-6: config shows ~/.fortshrc with legacy fallback (DOC-10)"
+
+th="$TEST_TMPDIR/confhome"
+mkdir -p "$th"
+echo 'echo from-fortshrc' > "$th/.fortshrc"
+out=$(HOME="$th" run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" --norc -c 'config' 2>&1)
+if printf '%s' "$out" | grep -q 'from-fortshrc' && ! printf '%s' "$out" | grep -q 'no .fortshrc'; then
+    pass "config displays ~/.fortshrc"
+else
+    fail "config displays ~/.fortshrc" "contents shown" "$out"
+fi
+rm -f "$th/.fortshrc"
+echo 'echo from-legacy' > "$th/.fshrc"
+out=$(HOME="$th" run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" --norc -c 'config' 2>&1)
+if printf '%s' "$out" | grep -q 'from-legacy'; then
+    pass "legacy ~/.fshrc fallback still works"
+else
+    fail "legacy ~/.fshrc fallback still works" "legacy contents shown" "$out"
+fi
+
 print_summary

--- a/tests/builtins/test_getopts.sh
+++ b/tests/builtins/test_getopts.sh
@@ -27,4 +27,19 @@ compare_output "getopts OPTIND reset between calls" 'f() { OPTIND=1; while getop
 compare_output "getopts preserves non-option args" 'f() { OPTIND=1; while getopts "v" opt; do echo "$opt"; done; shift $((OPTIND-1)); echo "$@"; }; f -v arg1 arg2'
 compare_output "getopts double-dash stops parsing" 'f() { OPTIND=1; while getopts "a" opt; do echo "$opt"; done; shift $((OPTIND-1)); echo "$@"; }; f -a -- -b'
 
+section "8. Wave-6: illegal-option diagnostic (BUILTIN-18)"
+
+out=$(run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" -c 'set -- -q; while getopts "ab:" o; do echo o=$o; done' 2>&1)
+if printf '%s' "$out" | grep -q 'illegal option -- q' && printf '%s' "$out" | grep -q 'o=?'; then
+    pass "non-silent mode prints illegal option"
+else
+    fail "non-silent mode prints illegal option" "diagnostic + o=?" "$out"
+fi
+out=$(run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" -c 'set -- -q; while getopts ":ab:" o; do echo "o=$o a=$OPTARG"; done' 2>&1)
+if [ "$out" = "o=? a=q" ]; then
+    pass "silent mode stays quiet with OPTARG set"
+else
+    fail "silent mode stays quiet with OPTARG set" "o=? a=q" "$out"
+fi
+
 print_summary

--- a/tests/builtins/test_set_shopt.sh
+++ b/tests/builtins/test_set_shopt.sh
@@ -27,4 +27,13 @@ check_exit "shopt -s extglob" 'shopt -s extglob 2>/dev/null; echo done' "0"
 compare_exit "shopt -q queries option" 'shopt -q login_shell 2>/dev/null; true'
 compare_exit "shopt -u unsets option" 'shopt -s extglob 2>/dev/null; shopt -u extglob 2>/dev/null; true'
 
+section "9. Wave-6: unknown options keep their error status (BUILTIN-14)"
+
+compare_exit "set -o badopt exits 2"     'set -o badopt'
+compare_exit "shopt -s badoption exits 1" 'shopt -s badoption'
+compare_exit "valid set -o still 0"      'set -o noglob'
+compare_exit "valid shopt -s still 0"    'shopt -s nullglob'
+compare_both "status readable after set" 'set -o badopt 2>/dev/null; echo $?'
+compare_both "status readable after shopt" 'shopt -s badoption 2>/dev/null; echo $?'
+
 print_summary

--- a/tests/builtins/test_type_command.sh
+++ b/tests/builtins/test_type_command.sh
@@ -23,4 +23,18 @@ section "3. which"
 compare_exit "which finds external command" 'which ls >/dev/null 2>&1'
 compare_exit "which nonexistent fails" 'which nonexistent_cmd_xyz_999 2>/dev/null'
 
+section "9. Wave-6: resolution table covers all live builtins (DOC-12)"
+
+compare_both "type : names a builtin"  'type :'
+compare_both "command -v :"            'command -v :; echo rc=$?'
+for b in config memory perf disown rawtest; do
+    out=$(run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" -c "command -v $b")
+    rc=$?
+    if [ "$rc" -eq 0 ] && [ "$out" = "$b" ]; then
+        pass "command -v $b resolves"
+    else
+        fail "command -v $b resolves" "$b (rc 0)" "rc=$rc out=$out"
+    fi
+done
+
 print_summary


### PR DESCRIPTION
Fixes all four Wave 6 findings. One commit per finding, each with regression tests (17 new cases across four existing suites).

- **BUILTIN-14** (M): `set` and `shopt` ran `last_exit_status = 0` unconditionally after their parse loops, so `set -o badopt` printed a diagnostic while `$?` read 0. Unknown options now exit 2 (`set`, bash convention) and 1 (`shopt`), preserved past the loop.
- **BUILTIN-18** (L): `getopts` prints `illegal option -- c` on stderr in non-silent mode; silent mode (leading `:`) stays quiet with OPTARG set, matching bash's asymmetry.
- **DOC-12** (L): the static resolution table behind `type`/`command -v` gained `:`, `config`, `memory`, `perf`, `disown`, `rawtest` — all executed as builtins but probed as "not found", breaking availability checks.
- **DOC-10** (L): bare `config` now displays `~/.fortshrc` (falling back to legacy `~/.fshrc`), mirroring the startup source order instead of claiming no config exists.

## Verification

- 1134/0 builtin tests, 479/0 integration, POSIX quick at the known-green baseline.
- Campaign standing: 59 of 85 findings resolved (waves 0-6).

Stacked on #68 (wave 5). Merge train: #66 → #67 → #68 → this.