### PR TITLE
Audit wave 5: read & printf builtins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,7 +288,7 @@ $(BUILDDIR)/scripting/test_builtin.o: src/scripting/test_builtin.f90 $(BUILDDIR)
 $(BUILDDIR)/scripting/advanced_test.o: src/scripting/advanced_test.f90 $(BUILDDIR)/common/types.o $(BUILDDIR)/scripting/variables.o $(BUILDDIR)/system/interface.o $(BUILDDIR)/common/io_helpers.o $(BUILDDIR)/scripting/expansion.o | $(BUILDDIR)/scripting
 	$(FC) $(FCFLAGS) -J$(BUILDDIR) -c $< -o $@
 
-$(BUILDDIR)/scripting/printf_builtin.o: src/scripting/printf_builtin.f90 $(BUILDDIR)/common/types.o | $(BUILDDIR)/scripting
+$(BUILDDIR)/scripting/printf_builtin.o: src/scripting/printf_builtin.f90 $(BUILDDIR)/common/types.o $(BUILDDIR)/common/io_helpers.o | $(BUILDDIR)/scripting
 	$(FC) $(FCFLAGS) -J$(BUILDDIR) -c $< -o $@
 
 $(BUILDDIR)/scripting/read_builtin.o: src/scripting/read_builtin.f90 $(BUILDDIR)/common/types.o $(BUILDDIR)/scripting/variables.o $(BUILDDIR)/system/interface.o | $(BUILDDIR)/scripting

--- a/src/c_interop/fd_wrapper.c
+++ b/src/c_interop/fd_wrapper.c
@@ -7,6 +7,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <pwd.h>
+#include <time.h>
 
 // Look up a user's home directory via getpwnam (for ~user expansion).
 // Returns the pw_dir string, or NULL if the user does not exist.
@@ -173,4 +174,24 @@ long long fortsh_stat_ino(const char *path) {
 extern char **environ;
 char *get_environ_ptr(int idx) {
     return environ[idx];
+}
+
+// Current Unix time, for printf %(fmt)T with argument -1/-2/absent.
+long long fortsh_time_now(void) {
+    return (long long)time(NULL);
+}
+
+// strftime an epoch through localtime, for printf %(fmt)T.
+int fortsh_strftime_epoch(const char *fmt, long long epoch, char *buf, int buflen) {
+    time_t t = (time_t)epoch;
+    struct tm tmv;
+    if (!localtime_r(&t, &tmv)) return 0;
+    return (int)strftime(buf, (size_t)buflen, fmt, &tmv);
+}
+
+// %a hex-float via the C library so the layout (long double
+// normalization) matches what the local bash printf produces.
+int fortsh_format_hexfloat(double v, int upper, char *buf, int buflen) {
+    int n = snprintf(buf, (size_t)buflen, upper ? "%LA" : "%La", (long double)v);
+    return n < 0 ? 0 : n;
 }

--- a/src/scripting/printf_builtin.f90
+++ b/src/scripting/printf_builtin.f90
@@ -4,8 +4,14 @@
 ! ==============================================================================
 module printf_builtin
   use shell_types
-  use iso_fortran_env, only: output_unit, error_unit
+  use iso_fortran_env, only: output_unit, error_unit, int64
+  use iso_c_binding, only: c_char, c_int, c_double, c_long_long, c_null_char
+  use io_helpers, only: parse_int64
   implicit none
+
+  ! Set when %b hits \c: all further printf output (including format
+  ! reuse for remaining arguments) stops immediately.
+  logical, save :: printf_stop = .false.
 
   ! Upper bound on printf field width/precision. A larger value (literal or via
   ! '*') would drive an unbounded buffer allocation and abort the shell.
@@ -23,7 +29,33 @@ module printf_builtin
     logical :: width_from_arg = .false. ! '*' for width
     logical :: prec_from_arg = .false.  ! '*' for precision
     character :: conversion = 's'       ! conversion specifier
+    character(len=64) :: time_format = '' ! strftime format for %(fmt)T
   end type
+
+  interface
+    function c_time_now() bind(C, name="fortsh_time_now")
+      import :: c_long_long
+      integer(c_long_long) :: c_time_now
+    end function c_time_now
+
+    function c_strftime_epoch(fmt, epoch, buf, buflen) bind(C, name="fortsh_strftime_epoch")
+      import :: c_char, c_long_long, c_int
+      character(kind=c_char), dimension(*), intent(in) :: fmt
+      integer(c_long_long), value :: epoch
+      character(kind=c_char), dimension(*), intent(out) :: buf
+      integer(c_int), value :: buflen
+      integer(c_int) :: c_strftime_epoch
+    end function c_strftime_epoch
+
+    function c_format_hexfloat(v, upper, buf, buflen) bind(C, name="fortsh_format_hexfloat")
+      import :: c_double, c_int, c_char
+      real(c_double), value :: v
+      integer(c_int), value :: upper
+      character(kind=c_char), dimension(*), intent(out) :: buf
+      integer(c_int), value :: buflen
+      integer(c_int) :: c_format_hexfloat
+    end function c_format_hexfloat
+  end interface
 
 contains
 
@@ -84,6 +116,7 @@ contains
 
     arg_index = 3
     fmt_error = .false.
+    printf_stop = .false.
 
     ! Size buffer based on argument content — each format cycle can produce
     ! up to sum(arg_lengths) + format_string_len of output
@@ -107,6 +140,8 @@ contains
         flush(output_unit)
       end if
 
+      ! %b \c ends all output, including format reuse
+      if (printf_stop) exit
       ! If no arguments were consumed, we're done (format has no specifiers or no more args)
       if (arg_index == prev_arg_index .or. arg_index > cmd%num_tokens) exit
     end do
@@ -202,6 +237,7 @@ contains
 
           ! Append formatted value to output (use exact length to preserve padding)
           call append_to_output_len(output, output_pos, formatted_value, fmt_len)
+          if (printf_stop) exit
         end if
       else if (current_char == char(92) .and. pos < format_len) then
         ! Handle escape sequences (backslash)
@@ -335,6 +371,30 @@ contains
         c = format_str(pos:pos)
       end if
 
+      ! %(fmt)T — strftime-style time conversion with its own parse shape
+      if (c == '(') then
+        block
+          integer :: close_p, sp
+          close_p = 0
+          sp = pos + 1
+          do while (sp <= format_len)
+            if (format_str(sp:sp) == ')') then
+              close_p = sp
+              exit
+            end if
+            sp = sp + 1
+          end do
+          if (close_p > 0 .and. close_p < format_len) then
+            if (format_str(close_p+1:close_p+1) == 'T') then
+              fmt_info%time_format = format_str(pos+1:close_p-1)
+              fmt_info%conversion = 'T'
+              pos = close_p + 2
+              return
+            end if
+          end if
+        end block
+      end if
+
       ! Check for conversion specifier
       if (index('diouxXeEfFgGaAcspbq', c) > 0) then
         fmt_info%conversion = c
@@ -356,7 +416,8 @@ contains
     logical, intent(out), optional :: had_error
 
     character(len=4096) :: raw_value, temp_value
-    integer :: int_val, status, val_len, pad_len, prec, actual_len
+    integer(int64) :: int_val
+    integer :: status, val_len, pad_len, prec, actual_len
     real(8) :: real_val
     character :: pad_char
 
@@ -386,8 +447,13 @@ contains
       end if
 
     case ('b')
-      ! %b: interpret backslash escapes in argument
-      call interpret_escapes(arg_value, raw_value)
+      ! %b: interpret backslash escapes; \c stops all further output
+      call interpret_escapes(arg_value, raw_value, printf_stop)
+      if (fmt_info%precision >= 0) then
+        if (fmt_info%precision < len_trim(raw_value)) then
+          raw_value(fmt_info%precision+1:) = ' '
+        end if
+      end if
 
     case ('c')
       ! Character
@@ -402,6 +468,7 @@ contains
       call parse_integer(arg_value, int_val, status)
       if (status == 0) then
         call format_integer(int_val, fmt_info, raw_value)
+        call apply_int_precision(raw_value, fmt_info%precision, int_val == 0_int64)
       else
         write(error_unit, '(a,a,a)') 'fortsh: printf: ', trim(arg_value), ': invalid number'
         if (present(had_error)) had_error = .true.
@@ -414,6 +481,7 @@ contains
       if (status == 0) then
         write(temp_value, '(O0)') int_val
         raw_value = trim(temp_value)
+        call apply_int_precision(raw_value, fmt_info%precision, int_val == 0_int64)
         if (fmt_info%alternate .and. int_val /= 0) then
           raw_value = '0' // trim(raw_value)
         end if
@@ -429,6 +497,7 @@ contains
       if (status == 0) then
         write(temp_value, '(Z0)') int_val
         raw_value = to_lowercase(trim(temp_value))
+        call apply_int_precision(raw_value, fmt_info%precision, int_val == 0_int64)
         if (fmt_info%alternate .and. int_val /= 0) then
           raw_value = '0x' // trim(raw_value)
         end if
@@ -444,6 +513,7 @@ contains
       if (status == 0) then
         write(temp_value, '(Z0)') int_val
         raw_value = to_uppercase(trim(temp_value))
+        call apply_int_precision(raw_value, fmt_info%precision, int_val == 0_int64)
         if (fmt_info%alternate .and. int_val /= 0) then
           raw_value = '0X' // trim(raw_value)
         end if
@@ -454,16 +524,53 @@ contains
       end if
 
     case ('u')
-      ! Unsigned integer (treat as regular integer in Fortran)
+      ! Unsigned 64-bit: negatives print their two's-complement magnitude
       call parse_integer(arg_value, int_val, status)
       if (status == 0) then
-        if (int_val < 0) int_val = int_val + 2147483647 + 1  ! Approximate unsigned
-        write(raw_value, '(I0)') int_val
+        call uint64_to_str(int_val, raw_value)
+        call apply_int_precision(raw_value, fmt_info%precision, int_val == 0_int64)
       else
         write(error_unit, '(a,a,a)') 'fortsh: printf: ', trim(arg_value), ': invalid number'
         if (present(had_error)) had_error = .true.
         raw_value = '0'
       end if
+
+    case ('a', 'A')
+      ! Hex float — via the C library so the layout matches the local bash
+      read(arg_value, *, iostat=status) real_val
+      if (status == 0) then
+        call hexfloat_to_str(real_val, fmt_info%conversion == 'A', raw_value)
+      else
+        if (len_trim(arg_value) > 0) then
+          write(error_unit, '(a,a,a)') 'fortsh: printf: ', trim(arg_value), ': invalid number'
+          if (present(had_error)) had_error = .true.
+        end if
+        raw_value = '0x0p+0'
+      end if
+
+    case ('T')
+      ! %(fmt)T — epoch seconds through strftime; -1/-2/missing mean now
+      block
+        integer(c_long_long) :: epoch
+        integer(int64) :: tval
+        logical :: tok_ok
+        if (actual_len == 0) then
+          epoch = c_time_now()
+        else
+          call parse_int64(arg_value(1:actual_len), tval, tok_ok)
+          if (.not. tok_ok) then
+            write(error_unit, '(a,a,a)') 'fortsh: printf: ', trim(arg_value), ': invalid number'
+            if (present(had_error)) had_error = .true.
+            tval = -1_int64
+          end if
+          if (tval == -1_int64 .or. tval == -2_int64) then
+            epoch = c_time_now()
+          else
+            epoch = int(tval, c_long_long)
+          end if
+        end if
+        call strftime_to_str(fmt_info%time_format, epoch, raw_value)
+      end block
 
     case ('f', 'F')
       ! Fixed-point notation
@@ -528,6 +635,7 @@ contains
         else
           raw_value = to_uppercase(raw_value)
         end if
+        call g_strip_zeros(raw_value)
       else
         if (len_trim(arg_value) > 0) then
           write(error_unit, '(a,a,a)') 'fortsh: printf: ', trim(arg_value), ': invalid number'
@@ -540,6 +648,11 @@ contains
       ! Shell-quoted string: escape special characters with backslash
       block
         integer :: qi, qo
+        if (actual_len == 0) then
+          ! bash prints '' so the empty value survives re-parsing
+          raw_value = "''"
+          actual_len = 2
+        else
         qo = 1
         raw_value = ''
         do qi = 1, actual_len
@@ -555,6 +668,7 @@ contains
           qo = qo + 1
         end do
         actual_len = qo - 1
+        end if
       end block
 
     case default
@@ -617,7 +731,7 @@ contains
 
   subroutine parse_integer(arg_value, int_val, status)
     character(len=*), intent(in) :: arg_value
-    integer, intent(out) :: int_val
+    integer(int64), intent(out) :: int_val
     integer, intent(out) :: status
 
     character(len=256) :: clean_arg
@@ -654,7 +768,7 @@ contains
   end subroutine
 
   subroutine format_integer(int_val, fmt_info, result)
-    integer, intent(in) :: int_val
+    integer(int64), intent(in) :: int_val
     type(format_info_t), intent(in) :: fmt_info
     character(len=*), intent(out) :: result
 
@@ -699,9 +813,123 @@ contains
     result = adjustl(temp)
   end subroutine
 
-  subroutine interpret_escapes(input, output)
+  ! Integer precision is a minimum digit count, zero-padded before the
+  ! sign-agnostic magnitude; %.0d of the value 0 emits no digits at all.
+  subroutine apply_int_precision(str, prec, value_is_zero)
+    character(len=*), intent(inout) :: str
+    integer, intent(in) :: prec
+    logical, intent(in) :: value_is_zero
+    character(len=80) :: digits_part
+    integer :: n, sl
+
+    if (prec < 0) return
+    n = len_trim(str)
+    sl = 0
+    if (n >= 1) then
+      if (str(1:1) == '-' .or. str(1:1) == '+' .or. str(1:1) == ' ') sl = 1
+    end if
+    if (prec == 0 .and. value_is_zero) then
+      str = ''
+      return
+    end if
+    if (n - sl < prec) then
+      digits_part = str(sl+1:n)
+      str = str(1:sl) // repeat('0', prec - (n - sl)) // trim(digits_part)
+    end if
+  end subroutine apply_int_precision
+
+  ! Decimal digits of an int64 reinterpreted as unsigned (two's
+  ! complement magnitude for negatives): ishft(v,-1) is a logical shift,
+  ! so (v>>1)/5 is the unsigned quotient by 10, off by at most one.
+  subroutine uint64_to_str(v, str)
+    integer(int64), intent(in) :: v
+    character(len=*), intent(out) :: str
+    integer(int64) :: q, r
+    character(len=24) :: tail
+
+    if (v >= 0_int64) then
+      write(str, '(I0)') v
+    else
+      q = ishft(v, -1) / 5_int64
+      r = v - q * 10_int64
+      if (r >= 10_int64) then
+        q = q + 1_int64
+        r = r - 10_int64
+      end if
+      write(tail, '(I0)') q
+      str = trim(tail) // achar(48 + int(r))
+    end if
+  end subroutine uint64_to_str
+
+  subroutine hexfloat_to_str(v, upper, str)
+    real(8), intent(in) :: v
+    logical, intent(in) :: upper
+    character(len=*), intent(out) :: str
+    character(kind=c_char) :: cbuf(64)
+    integer(c_int) :: n, up
+    integer :: k
+
+    up = 0
+    if (upper) up = 1
+    n = c_format_hexfloat(real(v, c_double), up, cbuf, 64)
+    str = ''
+    do k = 1, min(int(n), len(str), 64)
+      str(k:k) = cbuf(k)
+    end do
+  end subroutine hexfloat_to_str
+
+  subroutine strftime_to_str(fmt, epoch, str)
+    character(len=*), intent(in) :: fmt
+    integer(c_long_long), intent(in) :: epoch
+    character(len=*), intent(out) :: str
+    character(kind=c_char) :: fbuf(256), obuf(256)
+    integer(c_int) :: n
+    integer :: k, fl
+
+    fl = min(len_trim(fmt), 255)
+    do k = 1, fl
+      fbuf(k) = fmt(k:k)
+    end do
+    fbuf(fl+1) = c_null_char
+    n = c_strftime_epoch(fbuf, epoch, obuf, 256)
+    str = ''
+    do k = 1, min(int(n), len(str), 256)
+      str(k:k) = obuf(k)
+    end do
+  end subroutine strftime_to_str
+
+  ! %g strips trailing fractional zeros (and a bare trailing point),
+  ! in the mantissa when an exponent is present.
+  subroutine g_strip_zeros(str)
+    character(len=*), intent(inout) :: str
+    character(len=64) :: expart
+    integer :: epos, mend
+
+    epos = index(str, 'e')
+    if (epos == 0) epos = index(str, 'E')
+    if (epos > 0) then
+      expart = str(epos:len_trim(str))
+      mend = epos - 1
+    else
+      expart = ''
+      mend = len_trim(str)
+    end if
+    if (index(str(1:mend), '.') > 0) then
+      do while (mend > 1)
+        if (str(mend:mend) /= '0') exit
+        mend = mend - 1
+      end do
+      if (mend >= 1) then
+        if (str(mend:mend) == '.') mend = mend - 1
+      end if
+    end if
+    str = str(1:mend) // trim(expart)
+  end subroutine g_strip_zeros
+
+  subroutine interpret_escapes(input, output, stop_out)
     character(len=*), intent(in) :: input
     character(len=*), intent(out) :: output
+    logical, intent(out), optional :: stop_out
 
     integer :: pos, out_pos, input_len, octal_val, i
     character :: c
@@ -711,6 +939,7 @@ contains
     out_pos = 1
     input_len = len_trim(input)
     output = ''
+    if (present(stop_out)) stop_out = .false.
 
     do while (pos <= input_len .and. out_pos <= len(output))
       c = input(pos:pos)
@@ -720,6 +949,10 @@ contains
         c = input(pos:pos)
 
         select case (c)
+        case ('c')
+          ! \c: stop ALL printf output from here on
+          if (present(stop_out)) stop_out = .true.
+          return
         case ('n')
           output(out_pos:out_pos) = char(10)
         case ('t')

--- a/src/scripting/read_builtin.f90
+++ b/src/scripting/read_builtin.f90
@@ -141,10 +141,10 @@ contains
 
       actual_input_len = 0
       if (use_nchars) then
-        call read_n_characters(nchars, input_line)
+        call read_n_characters(nchars, input_line, eof_reached)
         actual_input_len = len_trim(input_line)
       else if (use_delimiter) then
-        call read_until_delimiter(delimiter, input_line)
+        call read_until_delimiter(delimiter, input_line, eof_reached)
         actual_input_len = len_trim(input_line)
       else if (use_timeout) then
         call read_with_timeout(timeout_sec, input_line, &
@@ -181,8 +181,9 @@ contains
         end if
       end if
 
-      ! Set exit status: 1 if EOF reached without reading any data, 0 otherwise
-      if (eof_reached .and. len_trim(input_line) == 0) then
+      ! bash: nonzero whenever EOF arrived before the delimiter, even if
+      ! partial data was read (and assigned to the variable)
+      if (eof_reached) then
         shell%last_exit_status = 1
       else
         shell%last_exit_status = 0
@@ -203,25 +204,28 @@ contains
     is_raw = .false.
     if (present(raw_mode)) is_raw = raw_mode
 
-    ! Use non-advancing I/O to get actual character count
+    ! Byte-level read so EOF before the newline is visible (BUILTIN-15):
+    ! the formatted layer reports a final unterminated record exactly like
+    ! a newline-ended one.
     input_line = ''
     nchars = 0
-    read(input_unit, '(a)', iostat=iostat, advance='no', &
-      size=nchars) input_line
-    if (iostat == IOSTAT_EOR .or. iostat == 0) then
-      if (present(eof_reached)) eof_reached = .false.
-      if (present(input_length)) input_length = nchars
-    else if (iostat == IOSTAT_END) then
-      input_line = ''
-      if (present(eof_reached)) eof_reached = .true.
-      if (present(input_length)) input_length = 0
-      return
-    else
-      input_line = ''
-      if (present(eof_reached)) eof_reached = .true.
-      if (present(input_length)) input_length = 0
-      return
-    end if
+    block
+      character :: bch
+      logical :: bgot, beof
+      do while (nchars < len(input_line))
+        call read_byte(bch, bgot, beof)
+        if (.not. bgot) then
+          if (present(eof_reached)) eof_reached = .true.
+          if (present(input_length)) input_length = nchars
+          return
+        end if
+        if (bch == char(10)) exit
+        nchars = nchars + 1
+        input_line(nchars:nchars) = bch
+      end do
+    end block
+    if (present(eof_reached)) eof_reached = .false.
+    if (present(input_length)) input_length = nchars
 
     ! POSIX: Without -r, backslash at end of line continues to next line
     if (.not. is_raw) then
@@ -247,40 +251,70 @@ contains
     end if
   end subroutine
 
-  subroutine read_n_characters(n, input_line)
+  ! Read one byte from fd 0. Bypasses Fortran's formatted layer, which
+  ! consumes a whole record per '(a1)' read (the BUILTIN-1 root cause) and
+  ! cannot distinguish a final unterminated record from a newline-ended
+  ! one (the BUILTIN-15 root cause).
+  subroutine read_byte(ch, got, at_eof)
+    use iso_c_binding, only: c_char, c_size_t, c_loc
+    use system_interface, only: c_read, STDIN_FD
+    character, intent(out) :: ch
+    logical, intent(out) :: got, at_eof
+    character(kind=c_char), target :: cbuf(1)
+    integer(c_size_t) :: nread
+
+    ch = ' '
+    got = .false.
+    at_eof = .false.
+    nread = c_read(STDIN_FD, c_loc(cbuf), 1_c_size_t)
+    if (nread == 1) then
+      ch = cbuf(1)
+      got = .true.
+    else
+      at_eof = .true.
+    end if
+  end subroutine read_byte
+
+  subroutine read_n_characters(n, input_line, eof_reached)
     integer, intent(in) :: n
     character(len=*), intent(out) :: input_line
-    
-    integer :: i, iostat
+    logical, intent(out) :: eof_reached
+
+    integer :: i
     character :: ch
-    
+    logical :: got
+
     input_line = ''
-    
-    do i = 1, min(n, len(input_line))
-      read(input_unit, '(a1)', iostat=iostat) ch
-      if (iostat /= 0) exit
+    eof_reached = .false.
+    i = 1
+    do while (i <= min(n, len(input_line)))
+      call read_byte(ch, got, eof_reached)
+      if (.not. got) return
+      ! bash: the default delimiter (newline) still ends read -n early
+      if (ch == char(10)) return
       input_line(i:i) = ch
+      i = i + 1
     end do
   end subroutine
 
-  subroutine read_until_delimiter(delimiter, input_line)
+  subroutine read_until_delimiter(delimiter, input_line, eof_reached)
     character, intent(in) :: delimiter
     character(len=*), intent(out) :: input_line
-    
+    logical, intent(out) :: eof_reached
+
     character :: ch
-    integer :: pos, iostat
-    
+    integer :: pos
+    logical :: got
+
     input_line = ''
+    eof_reached = .false.
     pos = 1
-    
+
     do while (pos <= len(input_line))
-      read(input_unit, '(a1)', iostat=iostat) ch
-      if (iostat /= 0) exit
-      
-      if (ch == delimiter) then
-        exit
-      end if
-      
+      call read_byte(ch, got, eof_reached)
+      if (.not. got) exit
+      if (ch == delimiter) exit
+      ! Newlines are ordinary data when the delimiter is something else
       input_line(pos:pos) = ch
       pos = pos + 1
     end do

--- a/tests/builtins/test_printf.sh
+++ b/tests/builtins/test_printf.sh
@@ -44,4 +44,56 @@ compare_output "printf %q shell-quoted string" 'printf "%q\n" "hello world"'
 compare_output "printf octal escape in format" 'printf "\101\n"'
 compare_output "printf hex escape in format" 'printf "\x41\n"'
 
+section "20. Wave-5: 64-bit integers and unsigned (BUILTIN-2, BUILTIN-16)"
+
+compare_both "%d past 2^31"          "printf '%d\n' 9999999999"
+compare_both "%x of -1 is 64-bit"    "printf '%x\n' -1"
+compare_both "%x past 2^32"          "printf '%x\n' 4294967296"
+compare_both "%u of -1"              "printf '%u\n' -1"
+compare_both "%u of -2"              "printf '%u\n' -2"
+compare_both "%u positive"           "printf '%u\n' 42"
+compare_both "small ints unchanged"  "printf '%d %05d %#x\n' 5 42 255"
+
+section "21. Wave-5: %b \\c terminator and precision (BUILTIN-8)"
+
+out=$(run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" -c "printf '%b\n' 'a\tb\c' ignored" | od -An -c | tr -s ' ')
+exp=$(run_with_timeout "$TEST_TIMEOUT" "$BASH_REF" -c "printf '%b\n' 'a\tb\c' ignored" | od -An -c | tr -s ' ')
+if [ "$out" = "$exp" ]; then
+    pass "\\c stops output, args, and the trailing newline"
+else
+    fail "\\c stops output, args, and the trailing newline" "$exp" "$out"
+fi
+compare_both "%.2b truncates"        "printf '%.2b\n' abcdef"
+
+section "22. Wave-5: %(fmt)T and %a (BUILTIN-9)"
+
+out=$(TZ=UTC run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" -c "printf '%(%Y)T\n' 0")
+exp=$(TZ=UTC run_with_timeout "$TEST_TIMEOUT" "$BASH_REF" -c "printf '%(%Y)T\n' 0")
+if [ "$out" = "$exp" ]; then
+    pass "%(%Y)T of epoch 0 in UTC"
+else
+    fail "%(%Y)T of epoch 0 in UTC" "$exp" "$out"
+fi
+compare_both "%(%s)T round-trips"    "printf '%(%s)T\n' 1234567890"
+compare_both "%a hex float"          "printf '%a\n' 1.5"
+compare_both "%A hex float"          "printf '%A\n' 1.5"
+
+section "23. Wave-5: %g trailing zeros (BUILTIN-10)"
+
+compare_both "%g large -> short exp" "printf '%g\n' 100000000"
+compare_both "%g strips zeros"       "printf '%g\n' 1.5"
+compare_both "%g integral value"     "printf '%g\n' 1.0"
+
+section "24. Wave-5: integer precision (BUILTIN-11)"
+
+compare_both "width and precision"   "printf '%5.3d\n' 7"
+compare_both "%.5x zero-pads"        "printf '%.5x\n' 255"
+compare_both "%.0d of 0 is empty"    "printf '[%.0d]\n' 0"
+compare_both "%.0d of 5 prints"      "printf '[%.0d]\n' 5"
+
+section "25. Wave-5: %q of empty string (BUILTIN-17)"
+
+compare_both "empty arg round-trips" "printf '[%q]\n' ''"
+compare_both "non-empty unchanged"   "printf '%q\n' 'a b'"
+
 print_summary

--- a/tests/builtins/test_read.sh
+++ b/tests/builtins/test_read.sh
@@ -36,4 +36,39 @@ compare_exit "read with no input returns 1" 'echo -n "" | read VAR'
 compare_output "read preserves whitespace with IFS empty" 'IFS= read line <<< "  spaces  "; echo ">$line<"'
 compare_output "read -r with trailing backslash" 'read -r VAR <<< "end\\"; echo "$VAR"'
 
+section "9. Wave-5: read -n / -d capture full spans (BUILTIN-1)"
+
+compare_both "-n 3 takes three chars"    'read -n 3 x <<< "abcdef"; echo "[$x]"'
+compare_both "-n 2 exact input"          'read -n 2 x <<< "ab"; echo "[$x]"'
+compare_both "-d , stops at comma"       'read -d , x <<< "hello,world"; echo "[$x]"'
+out=$(printf 'a\nb,' | run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" -c 'read -d , x; printf "[%s]\n" "$x"')
+exp=$(printf 'a\nb,' | run_with_timeout "$TEST_TIMEOUT" "$BASH_REF" -c 'read -d , x; printf "[%s]\n" "$x"')
+if [ "$out" = "$exp" ]; then
+    pass "-d , keeps newlines as data"
+else
+    fail "-d , keeps newlines as data" "$exp" "$out"
+fi
+
+section "10. Wave-5: EOF before delimiter is nonzero (BUILTIN-15)"
+
+out=$(printf 'no newline' | run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" -c 'read x; echo "rc=$? [$x]"')
+if [ "$out" = "rc=1 [no newline]" ]; then
+    pass "unterminated final line assigns data, rc=1"
+else
+    fail "unterminated final line assigns data, rc=1" "rc=1 [no newline]" "$out"
+fi
+out=$(printf 'with nl\n' | run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" -c 'read x; echo "rc=$? [$x]"')
+if [ "$out" = "rc=0 [with nl]" ]; then
+    pass "newline-terminated line still rc=0"
+else
+    fail "newline-terminated line still rc=0" "rc=0 [with nl]" "$out"
+fi
+out=$(printf 'a\nb\nc' | run_with_timeout "$TEST_TIMEOUT" "$FORTSH_BIN" -c 'while read x; do echo got [$x]; done')
+exp=$(printf 'a\nb\nc' | run_with_timeout "$TEST_TIMEOUT" "$BASH_REF" -c 'while read x; do echo got [$x]; done')
+if [ "$out" = "$exp" ]; then
+    pass "while-read drops the unterminated tail like bash"
+else
+    fail "while-read drops the unterminated tail like bash" "$exp" "$out"
+fi
+
 print_summary


### PR DESCRIPTION
Wave 5 of the adversarial-audit remediation (read and printf builtins). Recreated against trunk after the original #68 auto-closed when the wave-4 base branch was deleted on merge; same two commits.

- **BUILTIN-1 / BUILTIN-15** — `read` now uses byte-level fd reads, fixing `-n`/`-d` and the EOF exit status (EOF before delimiter returns 1 with data assigned).
- **BUILTIN-2/8/9/10/11/16/17** — `printf`: 64-bit integers, `%u`, `%b` with `\c`, `%(fmt)T`, `%a`, `%g` zero-stripping, integer precision, and `%q ''` → `''`.

All verified against local bash. Reopened here because GitHub cannot reopen a PR whose base branch was deleted.