### PR TITLE
Wave 8: readline redraw and input-cap fixes (RL-2, RL-1, QUAL-6, QUAL-8)

### DIFF
--- a/src/io/readline.f90
+++ b/src/io/readline.f90
@@ -12784,9 +12784,17 @@ contains
         w = 0; k = k + 1
       end if
       cursor_col = cursor_col + w
-      if (cursor_col >= term_cols) then
+      ! Deferred wrap: a char that lands EXACTLY on term_cols fills the row and
+      ! leaves the cursor in the terminal's pending-wrap state — still on this
+      ! physical row, not advanced. Only a char that OVERFLOWS past term_cols is
+      ! on the next row. Using '>= term_cols' here advanced the row one early, so
+      ! the trailing cursor's module_cursor_screen_row was one too high and the
+      ! next keystroke's move-up over-counted and scrolled the screen after an
+      ! exact-width paste. Reset to the overflow (not 0) so a wide char that
+      ! crosses the boundary keeps correct column accounting. (RL-1)
+      if (cursor_col > term_cols) then
         cursor_row = cursor_row + 1
-        cursor_col = 0
+        cursor_col = cursor_col - term_cols
       end if
     end do
   end subroutine

--- a/src/io/readline.f90
+++ b/src/io/readline.f90
@@ -2431,8 +2431,17 @@ contains
             ! Clear from cursor to end of screen
             call rdraw_append(char(27) // '[J')
 
-            ! Save cursor-up row count before content overwrites it
-            nav_cursor_row = current_row
+            ! Save cursor-up row count before content overwrites it. Use the
+            ! PHYSICAL row the old render left the cursor on
+            ! (module_cursor_screen_row), NOT current_row (the row the NEW,
+            ! possibly shorter, content's cursor lands on). When the old render
+            ! was taller than the new content (e.g. recalling a short line over a
+            ! wrapped one, or Ctrl-U on a wrapped recall), current_row
+            ! under-counts the physical rows, so the differential move-up below
+            ! stops short and ESC[J clears from a stale wrapped row — splicing
+            ! the new tail onto old content. This mirrors the full-rebuild path
+            ! at move_up_rows = module_cursor_screen_row above. (RL-2)
+            nav_cursor_row = module_cursor_screen_row
 
             ! Phase 2: mirror rendered content for line-level diff
             cframe_pos = 0

--- a/src/io/readline.f90
+++ b/src/io/readline.f90
@@ -80,14 +80,16 @@ module readline
   integer, parameter :: MAX_HISTORY = 100      ! Increased from 10 (heap-allocated array, safe)
 #ifdef USE_C_STRINGS
   ! C string library enabled - use larger buffers (tested working with flang-new 21.x)
-  integer, parameter :: MAX_LINE_LEN = 1024
+  integer, parameter :: MAX_LINE_LEN = 8192
 #else
-  ! Legacy limit for older flang-new versions without C string library
-  integer, parameter :: MAX_LINE_LEN = 128     ! Buffer size - actual limit is 127 chars!
+  ! Legacy limit for older flang-new versions without C string library. Raised
+  ! from 128 to match the mainline minimum; not used by CI (flang-new enables
+  ! USE_C_STRINGS), but 127 usable chars truncated far too early on that build.
+  integer, parameter :: MAX_LINE_LEN = 1024    ! Buffer size - actual limit is 1023 chars
 #endif
 #else
   integer, parameter :: MAX_HISTORY = 1000
-  integer, parameter :: MAX_LINE_LEN = 1024
+  integer, parameter :: MAX_LINE_LEN = 8192
 #endif
 
   ! Glob expansion constants (from glob module)
@@ -6201,9 +6203,14 @@ contains
 
     ! Check if we have room for one more character
     ! CRITICAL: Must be >= MAX_LINE_LEN - 1 to prevent writing to position MAX_LINE_LEN + 1
-    ! during middle insertions which shift characters right
+    ! during middle insertions which shift characters right.
+    ! At the cap, ring the bell instead of dropping the char silently (QUAL-6):
+    ! the input still fits far more than the old 1023, but overflow must be
+    ! audible rather than truncating the command invisibly on its way to exec.
     if (input_state%length >= MAX_LINE_LEN - 1) then
       if (allocated(temp_buffer)) deallocate(temp_buffer)
+      write(output_unit, '(a)', advance='no') char(7)
+      flush(output_unit)
       return
     end if
 

--- a/src/io/readline.f90
+++ b/src/io/readline.f90
@@ -6198,8 +6198,10 @@ contains
     ! moves cursor to the left edge, and clears selection state.
     if (input_state%selection_active) call delete_selection(input_state)
 
-    ! Allocate temp buffer on heap
-    allocate(character(len=MAX_LINE_LEN) :: temp_buffer)
+    ! temp_buffer (the right-shift scratch) is only needed for a middle
+    ! insertion; the append path never touches it. Allocate it lazily in the
+    ! else branch instead of on every keystroke — at MAX_LINE_LEN = 8192 the
+    ! per-keystroke append allocation was 8 KB of pure waste. (QUAL-8)
 
     ! Check if we have room for one more character
     ! CRITICAL: Must be >= MAX_LINE_LEN - 1 to prevent writing to position MAX_LINE_LEN + 1
@@ -6208,7 +6210,6 @@ contains
     ! the input still fits far more than the old 1023, but overflow must be
     ! audible rather than truncating the command invisibly on its way to exec.
     if (input_state%length >= MAX_LINE_LEN - 1) then
-      if (allocated(temp_buffer)) deallocate(temp_buffer)
       write(output_unit, '(a)', advance='no') char(7)
       flush(output_unit)
       return
@@ -6265,6 +6266,8 @@ contains
       end if
     else
       ! Insert in middle - use temp to avoid substring overlap issues
+      ! Allocate the right-shift scratch only here, where it is actually used.
+      allocate(character(len=MAX_LINE_LEN) :: temp_buffer)
       ! Initialize temp with current buffer
       call state_buffer_get(input_state, temp_buffer)
 

--- a/tests/interactive/conftest.py
+++ b/tests/interactive/conftest.py
@@ -124,3 +124,9 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "slow: marks tests as slow"
     )
+    config.addinivalue_line(
+        "markers",
+        "ci: pyte regression tests enforced by CI (run by run_tests.py "
+        "after the YAML specs). Mark a test ci only once it passes reliably "
+        "across Linux/ARM64/macOS PTY runs."
+    )

--- a/tests/interactive/run_tests.py
+++ b/tests/interactive/run_tests.py
@@ -529,7 +529,8 @@ def main():
     print(f"\nfortsh binary: {fortsh_path}")
 
     if args.pytest:
-        # Run pytest
+        # Run the entire pytest suite (developer use — includes tests not yet
+        # vetted for CI). CI runs only the `ci`-marked subset, below.
         import pytest
         test_dir = Path(__file__).parent
         return pytest.main([str(test_dir), '-v' if args.verbose else '-q'])
@@ -583,7 +584,25 @@ def main():
         generate_markdown_report(results, report_path)
         print(f"\nReport written to: {report_path}")
 
-    return 0 if failed == 0 else 1
+    exit_code = 0 if failed == 0 else 1
+
+    # When running the full suite (not a single --spec), also enforce the
+    # `ci`-marked pyte regression tests. These assert on-screen cursor/redraw
+    # state the YAML substring matcher cannot express (wrapped-line recall
+    # redraw, exact-width wrap, long-input cap). The rest of the pytest files
+    # are dev-only and run via --pytest.
+    if args.spec is None:
+        import pytest
+        print(f"\n{Fore.CYAN}=== pyte regression tests (ci-marked) ==={Style.RESET_ALL}")
+        pytest_dir = Path(__file__).parent
+        rc = pytest.main([str(pytest_dir), '-m', 'ci',
+                          '-v' if args.verbose else '-q', '-p', 'no:cacheprovider'])
+        # 5 == no tests collected (e.g. pyte missing → all deselected/skipped);
+        # don't fail the gate on an absent optional dependency.
+        if rc not in (0, 5):
+            exit_code = 1
+
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/tests/interactive/test_exact_width_wrap.py
+++ b/tests/interactive/test_exact_width_wrap.py
@@ -1,0 +1,92 @@
+"""Redraw regression test for an exact-width paste followed by a keystroke (RL-1).
+
+When a batch insert fills a row to exactly the terminal width, the terminal
+leaves the cursor in deferred (pending) wrap — still on the filled row. But
+cursor_get_row_col treated an exactly-filled row as advanced (its wrap test used
+'>='), so module_cursor_screen_row was one greater than the physical row and the
+next keystroke's move-up emitted one too many ESC[A, scrolling the screen. The
+fix treats an exact fill as pending-wrap. Verified via pyte cursor tracking and
+the emitted byte stream (the extra leading ESC[A must be gone).
+"""
+import os
+import time
+
+import pexpect
+import pytest
+
+try:
+    import pyte
+except ImportError:  # pragma: no cover
+    pyte = None
+
+pytestmark = pytest.mark.skipif(pyte is None, reason="pyte not installed")
+
+ROWS, COLS = 24, 80
+
+
+def test_exact_width_paste_then_key_no_extra_cursor_up(fortsh_path):
+    env = dict(os.environ)
+    env["TERM"] = "xterm-256color"
+    child = pexpect.spawn(fortsh_path, ["--norc"], env=env, encoding=None,
+                          timeout=8, dimensions=(ROWS, COLS))
+    screen = pyte.Screen(COLS, ROWS)
+    stream = pyte.ByteStream(screen)
+
+    def drain(secs=0.6):
+        end = time.time() + secs
+        while time.time() < end:
+            try:
+                stream.feed(child.read_nonblocking(65536, timeout=0.2))
+            except pexpect.TIMEOUT:
+                pass
+            except pexpect.EOF:
+                break
+
+    try:
+        time.sleep(1.0)
+        drain(1.0)
+
+        # The input-line prompt is '> ' (2 cols), so COLS-2 'a's fill the row to
+        # exactly the terminal width, leaving the cursor in pending wrap.
+        child.send(b"\x1b[200~" + b"a" * (COLS - 2) + b"\x1b[201~")
+        drain(0.6)
+
+        # Precondition: exact fill — cursor at the last column, still on the
+        # prompt's physical row (pending wrap, not advanced to the next row).
+        assert screen.cursor.x == COLS, (
+            f"expected exact-width fill (cursor.x == {COLS}), got "
+            f"cursor.x={screen.cursor.x}; prompt width may differ here"
+        )
+        fill_row = screen.cursor.y
+
+        # Type one char and capture exactly what the redraw emits.
+        raw = bytearray()
+        end = time.time() + 0.6
+        child.send(b"b")
+        while time.time() < end:
+            try:
+                raw.extend(child.read_nonblocking(65536, timeout=0.2))
+            except pexpect.TIMEOUT:
+                pass
+            except pexpect.EOF:
+                break
+
+        # The bug emitted the move-up first: the stream began with two ESC[A
+        # (one too many) before any content, because the exact-fill row was
+        # counted as advanced. The fix keeps the cursor on the filled row
+        # (pending wrap), so the redraw echoes the char and wraps normally.
+        assert not bytes(raw).startswith(b"\x1b[A\x1b[A"), (
+            "exact-width paste + keystroke emitted a leading double ESC[A "
+            "(over-counted move-up that scrolls the screen)"
+        )
+
+        # The typed char rendered on screen (buffer not corrupted by the redraw).
+        stream.feed(bytes(raw))
+        assert any("b" in r for r in screen.display), "typed char lost after redraw"
+    finally:
+        try:
+            child.send(b"\x03")
+            child.sendline(b"exit")
+            child.close()
+        except Exception:
+            pass

--- a/tests/interactive/test_exact_width_wrap.py
+++ b/tests/interactive/test_exact_width_wrap.py
@@ -19,7 +19,10 @@ try:
 except ImportError:  # pragma: no cover
     pyte = None
 
-pytestmark = pytest.mark.skipif(pyte is None, reason="pyte not installed")
+pytestmark = [
+    pytest.mark.ci,
+    pytest.mark.skipif(pyte is None, reason="pyte not installed"),
+]
 
 ROWS, COLS = 24, 80
 

--- a/tests/interactive/test_long_input.py
+++ b/tests/interactive/test_long_input.py
@@ -12,6 +12,8 @@ import time
 import pexpect
 import pytest
 
+pytestmark = pytest.mark.ci
+
 ROWS, COLS = 24, 80
 
 

--- a/tests/interactive/test_long_input.py
+++ b/tests/interactive/test_long_input.py
@@ -1,0 +1,68 @@
+"""Long interactive input must reach execution, not truncate silently (QUAL-6).
+
+insert_char_impl dropped characters once the line reached MAX_LINE_LEN-1 (1023)
+with no feedback, and the truncated command still ran. A 1100-char `echo`
+therefore executed with only 1018 a's. The cap is raised (well above normal use)
+and overflow now rings the bell instead of dropping silently. This asserts the
+audit's repro: a 1100-char command reaches execution in full, like bash.
+"""
+import os
+import time
+
+import pexpect
+import pytest
+
+ROWS, COLS = 24, 80
+
+
+def _longest_run(data: bytes, ch: int) -> int:
+    longest = cur = 0
+    for b in data:
+        if b == ch:
+            cur += 1
+            longest = max(longest, cur)
+        else:
+            cur = 0
+    return longest
+
+
+def test_1100_char_command_reaches_execution(fortsh_path):
+    env = dict(os.environ)
+    env["TERM"] = "xterm-256color"
+    child = pexpect.spawn(fortsh_path, ["--norc"], env=env, encoding=None,
+                          timeout=12, dimensions=(ROWS, COLS))
+    out = bytearray()
+
+    def drain(secs=1.5):
+        end = time.time() + secs
+        while time.time() < end:
+            try:
+                out.extend(child.read_nonblocking(65536, timeout=0.2))
+            except pexpect.TIMEOUT:
+                pass
+            except pexpect.EOF:
+                break
+
+    try:
+        time.sleep(1.0)
+        drain(1.0)
+        n = 1100
+        child.send(b"echo " + b"a" * n)
+        drain(1.5)
+        out.clear()
+        child.send(b"\r")
+        drain(2.0)
+        # echo prints all n a's on its own line; the run must be the full n,
+        # not the old 1023-5 = 1018 truncation.
+        longest = _longest_run(bytes(out), ord("a"))
+        assert longest == n, (
+            f"echo output's longest a-run was {longest}, expected {n} "
+            f"(input truncated before reaching execution)"
+        )
+    finally:
+        try:
+            child.send(b"\x03")
+            child.sendline(b"exit")
+            child.close()
+        except Exception:
+            pass

--- a/tests/interactive/test_wrapped_recall.py
+++ b/tests/interactive/test_wrapped_recall.py
@@ -21,7 +21,10 @@ try:
 except ImportError:  # pragma: no cover
     pyte = None
 
-pytestmark = pytest.mark.skipif(pyte is None, reason="pyte not installed")
+pytestmark = [
+    pytest.mark.ci,
+    pytest.mark.skipif(pyte is None, reason="pyte not installed"),
+]
 
 ROWS, COLS = 24, 80
 

--- a/tests/interactive/test_wrapped_recall.py
+++ b/tests/interactive/test_wrapped_recall.py
@@ -1,0 +1,118 @@
+"""Redraw regression tests for history recall / Ctrl-U over a wrapped line (RL-2).
+
+When a wrapped multi-row line is replaced by shorter content, the differential
+redraw used to reposition the cursor by the model row (current_row) instead of
+the physical row (module_cursor_screen_row). The move-up under-shot, ESC[J
+cleared from a stale wrapped row, and the new tail was spliced onto old content:
+recalling `echo short` over a wrapped z-line displayed `echo zzz...zzzshort`
+while Enter still executed `echo short`. The fix repositions by the physical row.
+
+These assert terminal-cell layout via pyte, which the YAML/byte harness can't
+express — the bug is that the rendered screen diverges from the executed buffer.
+"""
+import os
+import time
+
+import pexpect
+import pytest
+
+try:
+    import pyte
+except ImportError:  # pragma: no cover
+    pyte = None
+
+pytestmark = pytest.mark.skipif(pyte is None, reason="pyte not installed")
+
+ROWS, COLS = 24, 80
+
+
+def _spawn(fortsh_path):
+    env = dict(os.environ)
+    env["TERM"] = "xterm-256color"
+    child = pexpect.spawn(fortsh_path, ["--norc"], env=env, encoding=None,
+                          timeout=8, dimensions=(ROWS, COLS))
+    screen = pyte.Screen(COLS, ROWS)
+    stream = pyte.ByteStream(screen)
+
+    def drain(secs=0.6):
+        end = time.time() + secs
+        while time.time() < end:
+            try:
+                stream.feed(child.read_nonblocking(65536, timeout=0.2))
+            except pexpect.TIMEOUT:
+                pass
+            except pexpect.EOF:
+                break
+
+    time.sleep(1.0)
+    drain(1.0)
+    return child, screen, drain
+
+
+def _active_input_row(screen):
+    """Return the command text on the active input line: the last row whose
+    prompt marker is '>' (the default prompt's final physical row is
+    '> <command>'). Handles the empty case where the row rstrips to just '>'.
+    Earlier '>' rows are scrollback prompts, so the last one is the live line."""
+    rows = [r.rstrip() for r in screen.display]
+    for r in reversed(rows):
+        if r.startswith(">"):
+            rest = r[1:]
+            if rest.startswith(" "):
+                rest = rest[1:]
+            return rest
+    return None
+
+
+def _close(child):
+    try:
+        child.send(b"\x03")
+        child.sendline(b"exit")
+        child.close()
+    except Exception:
+        pass
+
+
+def test_recall_short_line_over_wrapped_matches_buffer(fortsh_path):
+    """Recall `echo short` over a wrapped z-line: the displayed input line must
+    read `echo short`, not the z-run with `short` spliced on."""
+    child, screen, drain = _spawn(fortsh_path)
+    try:
+        child.send(b"echo short\r")
+        drain(0.5)
+        child.send(b"echo " + b"z" * 90 + b"\r")   # 95 cols -> wraps
+        drain(0.6)
+        child.send(b"\x1b[A")   # Up -> wrapped z-line
+        drain(0.5)
+        child.send(b"\x1b[A")   # Up -> echo short
+        drain(0.6)
+
+        active = _active_input_row(screen)
+        assert active == "echo short", (
+            f"displayed input line was {active!r}, expected 'echo short' "
+            f"(display diverged from the recalled buffer)"
+        )
+        assert "zz" not in active, "stale wrapped content spliced into recall"
+    finally:
+        _close(child)
+
+
+def test_ctrl_u_on_wrapped_recall_clears_line(fortsh_path):
+    """Recall the wrapped z-line, then Ctrl-U: the input line must clear to
+    empty rather than leaving stale wrapped content on screen."""
+    child, screen, drain = _spawn(fortsh_path)
+    try:
+        child.send(b"echo " + b"z" * 90 + b"\r")
+        drain(0.6)
+        child.send(b"\x1b[A")   # Up -> wrapped z-line
+        drain(0.6)
+        child.send(b"\x15")     # Ctrl-U -> kill whole line
+        drain(0.6)
+
+        active = _active_input_row(screen)
+        assert active == "", (
+            f"input line after Ctrl-U was {active!r}, expected empty "
+            f"(stale wrapped content not cleared)"
+        )
+    finally:
+        _close(child)


### PR DESCRIPTION
Readline redraw and input-cap fixes from the wave-8 audit slice, plus wiring so the new PTY regression tests actually run in CI.

## Findings

- **RL-2** — wrapped-line history recall and Ctrl-U left stale glyphs on screen. The differential redraw saved the model row (`current_row`) instead of the physical screen row; it now saves `module_cursor_screen_row`.
- **RL-1** — pasting a line that exactly fills the terminal width, then pressing a key, emitted an extra cursor-up and scrolled a line off the top. `cursor_get_row_col` now treats an exactly-width-filled row as a pending wrap (`>` not `>=`), matching the terminal's deferred-wrap behavior.
- **QUAL-6** — input was silently truncated at `MAX_LINE_LEN-1` (1023) and the truncated command still ran (a 1100-char `echo` executed with 1018 a's). Raised the cap (Linux and Apple+C_STRINGS 1024→8192, Apple legacy 128→1024) and ring the bell on overflow instead of dropping characters. flang-new's known bug is with ALLOCATABLE deferred-length strings, not fixed buffers, so raising the fixed cap is safe.
- **QUAL-8** — `insert_char_impl` allocated a `MAX_LINE_LEN` scratch buffer on every keystroke; it now allocates only on the middle-insertion path.

QUAL-13 (split the 12k-line readline module) is deferred: maintainability-only and the highest regression risk in the slice.

## Tests

- New pyte screen-scrape regressions: `test_wrapped_recall.py` (RL-2, 2 cases), `test_exact_width_wrap.py` (RL-1), `test_long_input.py` (QUAL-6). Each was verified to fail before its fix and pass after.
- CI previously invoked only `run_tests.py` (YAML specs); the `test_*.py` pytest files ran solely under `--pytest`, so these screen-scrape assertions were never enforced. `run_tests.py` now runs `pytest -m ci` after the YAML specs and folds the result into its exit code. The three files above are marked `ci`; the rest stay dev-only (13 currently fail — tracked locally as DISC-6, not wave-8 scope).
- Full local gate: 1079 YAML + 4 ci pytest, 0 failed.
