### PR TITLE
Wave 11: performance & maintainability (QUAL-7/10/12)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ endif
 # (the .o is a proxy for the .mod gfortran emits alongside it) or parallel
 # builds race on missing .mod files.
 OBJECTS = $(BUILDDIR)/common/types.o \
+          $(BUILDDIR)/common/string_utils.o \
           $(BUILDDIR)/common/version.o \
           $(BUILDDIR)/common/error_handling.o \
           $(BUILDDIR)/common/performance.o \
@@ -197,6 +198,9 @@ $(TARGET): $(OBJECTS) $(CORE_C_OBJS) $(C_STRING_OBJ) $(C_STRING_LIB) | $(BINDIR)
 $(BUILDDIR)/common/types.o: src/common/types.f90 | $(BUILDDIR)/common
 	$(FC) $(FCFLAGS) -J$(BUILDDIR) -c $< -o $@
 
+$(BUILDDIR)/common/string_utils.o: src/common/string_utils.f90 | $(BUILDDIR)/common
+	$(FC) $(FCFLAGS) -J$(BUILDDIR) -c $< -o $@
+
 $(BUILDDIR)/common/version.o: src/common/version.f90 | $(BUILDDIR)/common
 	$(FC) $(FCFLAGS) -J$(BUILDDIR) -c $< -o $@
 
@@ -224,7 +228,7 @@ $(BUILDDIR)/system/interface.o: src/system/interface.f90 $(BUILDDIR)/common/type
 $(BUILDDIR)/common/io_helpers.o: src/common/io_helpers.f90 $(BUILDDIR)/system/interface.o | $(BUILDDIR)/common
 	$(FC) $(FCFLAGS) -J$(BUILDDIR) -c $< -o $@
 
-$(BUILDDIR)/system/signals.o: src/system/signals.f90 $(BUILDDIR)/system/interface.o $(BUILDDIR)/common/types.o | $(BUILDDIR)/system
+$(BUILDDIR)/system/signals.o: src/system/signals.f90 $(BUILDDIR)/system/interface.o $(BUILDDIR)/common/types.o $(BUILDDIR)/common/string_utils.o | $(BUILDDIR)/system
 	$(FC) $(FCFLAGS) -J$(BUILDDIR) -c $< -o $@
 
 $(BUILDDIR)/system/signal_handling.o: src/system/signal_handling.f90 $(BUILDDIR)/common/types.o | $(BUILDDIR)/system
@@ -287,7 +291,7 @@ $(BUILDDIR)/scripting/test_builtin.o: src/scripting/test_builtin.f90 $(BUILDDIR)
 $(BUILDDIR)/scripting/advanced_test.o: src/scripting/advanced_test.f90 $(BUILDDIR)/common/types.o $(BUILDDIR)/scripting/variables.o $(BUILDDIR)/system/interface.o $(BUILDDIR)/common/io_helpers.o $(BUILDDIR)/scripting/expansion.o | $(BUILDDIR)/scripting
 	$(FC) $(FCFLAGS) -J$(BUILDDIR) -c $< -o $@
 
-$(BUILDDIR)/scripting/printf_builtin.o: src/scripting/printf_builtin.f90 $(BUILDDIR)/common/types.o $(BUILDDIR)/common/io_helpers.o | $(BUILDDIR)/scripting
+$(BUILDDIR)/scripting/printf_builtin.o: src/scripting/printf_builtin.f90 $(BUILDDIR)/common/types.o $(BUILDDIR)/common/io_helpers.o $(BUILDDIR)/common/string_utils.o | $(BUILDDIR)/scripting
 	$(FC) $(FCFLAGS) -J$(BUILDDIR) -c $< -o $@
 
 $(BUILDDIR)/scripting/read_builtin.o: src/scripting/read_builtin.f90 $(BUILDDIR)/common/types.o $(BUILDDIR)/scripting/variables.o $(BUILDDIR)/system/interface.o | $(BUILDDIR)/scripting
@@ -305,10 +309,10 @@ $(BUILDDIR)/scripting/command_builtin.o: src/scripting/command_builtin.f90 $(BUI
 $(BUILDDIR)/scripting/variables.o: src/scripting/variables.f90 $(BUILDDIR)/common/types.o $(BUILDDIR)/system/interface.o $(BUILDDIR)/common/io_helpers.o | $(BUILDDIR)/scripting
 	$(FC) $(FCFLAGS) -J$(BUILDDIR) -c $< -o $@
 
-$(BUILDDIR)/scripting/prompt_formatting.o: src/scripting/prompt_formatting.f90 $(BUILDDIR)/common/types.o $(BUILDDIR)/system/interface.o $(BUILDDIR)/scripting/substitution.o $(BUILDDIR)/scripting/variables.o | $(BUILDDIR)/scripting
+$(BUILDDIR)/scripting/prompt_formatting.o: src/scripting/prompt_formatting.f90 $(BUILDDIR)/common/types.o $(BUILDDIR)/system/interface.o $(BUILDDIR)/scripting/substitution.o $(BUILDDIR)/scripting/variables.o $(BUILDDIR)/common/string_utils.o | $(BUILDDIR)/scripting
 	$(FC) $(FCFLAGS) -J$(BUILDDIR) -c $< -o $@
 
-$(BUILDDIR)/scripting/expansion.o: src/scripting/expansion.f90 $(BUILDDIR)/common/types.o $(BUILDDIR)/scripting/variables.o $(BUILDDIR)/execution/command_capture.o $(BUILDDIR)/parsing/glob.o $(BUILDDIR)/system/interface.o | $(BUILDDIR)/scripting
+$(BUILDDIR)/scripting/expansion.o: src/scripting/expansion.f90 $(BUILDDIR)/common/types.o $(BUILDDIR)/scripting/variables.o $(BUILDDIR)/execution/command_capture.o $(BUILDDIR)/parsing/glob.o $(BUILDDIR)/system/interface.o $(BUILDDIR)/common/string_utils.o | $(BUILDDIR)/scripting
 	$(FC) $(FCFLAGS) -J$(BUILDDIR) -c $< -o $@
 
 $(BUILDDIR)/scripting/substitution.o: src/scripting/substitution.f90 $(BUILDDIR)/common/types.o $(BUILDDIR)/system/interface.o $(BUILDDIR)/execution/command_capture.o | $(BUILDDIR)/scripting
@@ -338,10 +342,10 @@ $(BUILDDIR)/scripting/completion.o: src/scripting/completion.f90 $(BUILDDIR)/com
 $(BUILDDIR)/io/syntax_highlight.o: src/io/syntax_highlight.f90 $(BUILDDIR)/system/interface.o $(BUILDDIR)/common/string_pool.o | $(BUILDDIR)/io
 	$(FC) $(FCFLAGS) -J$(BUILDDIR) -c $< -o $@
 
-$(BUILDDIR)/io/suggestions.o: src/io/suggestions.f90 | $(BUILDDIR)/io
+$(BUILDDIR)/io/suggestions.o: src/io/suggestions.f90 $(BUILDDIR)/common/string_utils.o | $(BUILDDIR)/io
 	$(FC) $(FCFLAGS) -J$(BUILDDIR) -c $< -o $@
 
-$(BUILDDIR)/io/readline.o: src/io/readline.f90 $(BUILDDIR)/common/types.o $(BUILDDIR)/common/buffer_ops.o $(BUILDDIR)/system/interface.o $(BUILDDIR)/io/syntax_highlight.o $(BUILDDIR)/io/suggestions.o $(BUILDDIR)/scripting/abbreviations.o $(BUILDDIR)/parsing/glob.o $(BUILDDIR)/scripting/completion.o $(C_STRING_OBJ) $(BUILDDIR)/common/memory_dashboard.o $(BUILDDIR)/common/string_pool.o $(BUILDDIR)/system/signals.o | $(BUILDDIR)/io
+$(BUILDDIR)/io/readline.o: src/io/readline.f90 $(BUILDDIR)/common/types.o $(BUILDDIR)/common/buffer_ops.o $(BUILDDIR)/system/interface.o $(BUILDDIR)/io/syntax_highlight.o $(BUILDDIR)/io/suggestions.o $(BUILDDIR)/scripting/abbreviations.o $(BUILDDIR)/parsing/glob.o $(BUILDDIR)/scripting/completion.o $(C_STRING_OBJ) $(BUILDDIR)/common/memory_dashboard.o $(BUILDDIR)/common/string_pool.o $(BUILDDIR)/system/signals.o $(BUILDDIR)/common/string_utils.o | $(BUILDDIR)/io
 	$(FC) $(FCFLAGS) -J$(BUILDDIR) -c $< -o $@
 
 $(BUILDDIR)/io/fd_redirection.o: src/io/fd_redirection.f90 $(BUILDDIR)/common/types.o $(BUILDDIR)/system/interface.o $(BUILDDIR)/common/io_helpers.o $(BUILDDIR)/scripting/variables.o | $(BUILDDIR)/io

--- a/src/common/string_utils.f90
+++ b/src/common/string_utils.f90
@@ -1,0 +1,75 @@
+! Shared ASCII case-conversion helpers.
+!
+! Consolidates the string- and char-level to_upper/to_lower copies that had
+! drifted across six modules (expansion, signals, printf_builtin,
+! prompt_formatting, suggestions, readline). All operate on ASCII only: a
+! letter is shifted by 32, everything else passes through unchanged.
+!
+! String and char helpers carry distinct names on purpose — a Fortran generic
+! interface cannot disambiguate a len=* scalar from a len=1 scalar (same type,
+! kind and rank), so consumers rename on import (e.g. to_lowercase => char_lower)
+! to keep their existing call sites unchanged.
+module string_utils
+  implicit none
+  private
+
+  public :: to_upper, to_lower       ! whole-string
+  public :: char_upper, char_lower   ! single character
+
+contains
+
+  pure function to_upper(input) result(output)
+    character(len=*), intent(in) :: input
+    character(len=len(input)) :: output
+    integer :: i, code
+
+    output = input
+    do i = 1, len_trim(input)
+      code = iachar(input(i:i))
+      if (code >= iachar('a') .and. code <= iachar('z')) then
+        output(i:i) = achar(code - 32)
+      end if
+    end do
+  end function to_upper
+
+  pure function to_lower(input) result(output)
+    character(len=*), intent(in) :: input
+    character(len=len(input)) :: output
+    integer :: i, code
+
+    output = input
+    do i = 1, len_trim(input)
+      code = iachar(input(i:i))
+      if (code >= iachar('A') .and. code <= iachar('Z')) then
+        output(i:i) = achar(code + 32)
+      end if
+    end do
+  end function to_lower
+
+  pure function char_upper(c) result(uc)
+    character(len=1), intent(in) :: c
+    character(len=1) :: uc
+    integer :: code
+
+    code = iachar(c)
+    if (code >= iachar('a') .and. code <= iachar('z')) then
+      uc = achar(code - 32)
+    else
+      uc = c
+    end if
+  end function char_upper
+
+  pure function char_lower(c) result(lc)
+    character(len=1), intent(in) :: c
+    character(len=1) :: lc
+    integer :: code
+
+    code = iachar(c)
+    if (code >= iachar('A') .and. code <= iachar('Z')) then
+      lc = achar(code + 32)
+    else
+      lc = c
+    end if
+  end function char_lower
+
+end module string_utils

--- a/src/execution/builtins.f90
+++ b/src/execution/builtins.f90
@@ -57,67 +57,78 @@ contains
   function is_builtin_impl(cmd_name) result(is_built)
     character(len=*), intent(in) :: cmd_name
     logical :: is_built
+    integer :: nlen
+    character(len=32) :: n
 
-    is_built = (trim(cmd_name) == 'exit' .or. &
-                trim(cmd_name) == 'cd' .or. &
-                trim(cmd_name) == 'pwd' .or. &
-                trim(cmd_name) == 'pushd' .or. &
-                trim(cmd_name) == 'popd' .or. &
-                trim(cmd_name) == 'dirs' .or. &
-                trim(cmd_name) == 'prevd' .or. &
-                trim(cmd_name) == 'nextd' .or. &
-                trim(cmd_name) == 'dirh' .or. &
-                trim(cmd_name) == 'export' .or. &
-                trim(cmd_name) == 'echo' .or. &
-                trim(cmd_name) == 'jobs' .or. &
-                trim(cmd_name) == 'fg' .or. &
-                trim(cmd_name) == 'bg' .or. &
-                trim(cmd_name) == 'disown' .or. &
-                trim(cmd_name) == 'source' .or. &
-                trim(cmd_name) == '.' .or. &
-                trim(cmd_name) == ':' .or. &
-                trim(cmd_name) == 'history' .or. &
-                trim(cmd_name) == 'kill' .or. &
-                trim(cmd_name) == 'wait' .or. &
-                trim(cmd_name) == 'trap' .or. &
-                trim(cmd_name) == 'config' .or. &
-                trim(cmd_name) == 'alias' .or. &
-                trim(cmd_name) == 'unalias' .or. &
-                trim(cmd_name) == 'abbr' .or. &
-                trim(cmd_name) == 'help' .or. &
-                trim(cmd_name) == 'perf' .or. &
-                trim(cmd_name) == 'memory' .or. &
-                trim(cmd_name) == 'rawtest' .or. &
-                trim(cmd_name) == 'defun' .or. &
-                trim(cmd_name) == 'set' .or. &
-                trim(cmd_name) == 'shopt' .or. &
-                trim(cmd_name) == 'type' .or. &
-                trim(cmd_name) == 'which' .or. &
-                trim(cmd_name) == 'command' .or. &
-                trim(cmd_name) == 'unset' .or. &
-                trim(cmd_name) == 'readonly' .or. &
-                trim(cmd_name) == 'declare' .or. &
-                trim(cmd_name) == 'printenv' .or. &
-                trim(cmd_name) == 'local' .or. &
-                trim(cmd_name) == 'shift' .or. &
-                trim(cmd_name) == 'break' .or. &
-                trim(cmd_name) == 'continue' .or. &
-                trim(cmd_name) == 'return' .or. &
-                trim(cmd_name) == 'exec' .or. &
-                trim(cmd_name) == 'eval' .or. &
-                trim(cmd_name) == 'hash' .or. &
-                trim(cmd_name) == 'umask' .or. &
-                trim(cmd_name) == 'ulimit' .or. &
-                trim(cmd_name) == 'times' .or. &
-                trim(cmd_name) == 'let' .or. &
-                trim(cmd_name) == 'getopts' .or. &
-                trim(cmd_name) == 'printf' .or. &
-                trim(cmd_name) == 'read' .or. &
-                trim(cmd_name) == 'fc' .or. &
-                trim(cmd_name) == 'coproc' .or. &
-                trim(cmd_name) == 'complete' .or. &
-                trim(cmd_name) == 'compgen' .or. &
-                is_test_command(cmd_name))
+    ! Bucket on the first character so each dispatch compares only the few
+    ! builtin names sharing that initial letter instead of sweeping the whole
+    ! ~60-name table (Fortran .or. is not guaranteed to short-circuit, so the
+    ! old flat chain could evaluate every comparison). Names longer than the
+    ! buffer cannot be builtins, so skip straight to the test-command fallback.
+    is_built = .false.
+    nlen = len_trim(cmd_name)
+    if (nlen == 0) return
+
+    if (nlen <= len(n)) then
+      n = cmd_name(1:nlen)
+      select case (cmd_name(1:1))
+      case ('.')
+        is_built = (n == '.')
+      case (':')
+        is_built = (n == ':')
+      case ('a')
+        is_built = (n == 'alias' .or. n == 'abbr')
+      case ('b')
+        is_built = (n == 'bg' .or. n == 'break')
+      case ('c')
+        is_built = (n == 'cd' .or. n == 'config' .or. n == 'command' .or. &
+                    n == 'continue' .or. n == 'coproc' .or. n == 'complete' .or. &
+                    n == 'compgen')
+      case ('d')
+        is_built = (n == 'dirs' .or. n == 'dirh' .or. n == 'disown' .or. &
+                    n == 'defun' .or. n == 'declare')
+      case ('e')
+        is_built = (n == 'exit' .or. n == 'export' .or. n == 'echo' .or. &
+                    n == 'exec' .or. n == 'eval')
+      case ('f')
+        is_built = (n == 'fg' .or. n == 'fc')
+      case ('g')
+        is_built = (n == 'getopts')
+      case ('h')
+        is_built = (n == 'history' .or. n == 'help' .or. n == 'hash')
+      case ('j')
+        is_built = (n == 'jobs')
+      case ('k')
+        is_built = (n == 'kill')
+      case ('l')
+        is_built = (n == 'local' .or. n == 'let')
+      case ('m')
+        is_built = (n == 'memory')
+      case ('n')
+        is_built = (n == 'nextd')
+      case ('p')
+        is_built = (n == 'pwd' .or. n == 'pushd' .or. n == 'popd' .or. &
+                    n == 'prevd' .or. n == 'perf' .or. n == 'printenv' .or. &
+                    n == 'printf')
+      case ('r')
+        is_built = (n == 'rawtest' .or. n == 'readonly' .or. n == 'return' .or. &
+                    n == 'read')
+      case ('s')
+        is_built = (n == 'source' .or. n == 'set' .or. n == 'shopt' .or. &
+                    n == 'shift')
+      case ('t')
+        is_built = (n == 'trap' .or. n == 'type' .or. n == 'times')
+      case ('u')
+        is_built = (n == 'unalias' .or. n == 'unset' .or. n == 'umask' .or. &
+                    n == 'ulimit')
+      case ('w')
+        is_built = (n == 'wait' .or. n == 'which')
+      end select
+    end if
+
+    ! Test-command family ('[', '[[', 'test'): '[' and '[[' fall through the
+    ! select above, and 'test' is deliberately left out of the 't' bucket.
+    if (.not. is_built) is_built = is_test_command(cmd_name)
   end function
 
   subroutine execute_builtin_impl(cmd, shell)

--- a/src/execution/coprocess.f90
+++ b/src/execution/coprocess.f90
@@ -361,13 +361,6 @@ contains
     num_coprocs = 0
   end subroutine
 
-  function int_to_string(val) result(str)
-    integer, intent(in) :: val
-    character(len=32) :: str
-    
-    write(str, '(I0)') val
-  end function
-
   subroutine execute_command_native(command, shell)
     use trap_dispatch, only: eval_trap_string
     character(len=*), intent(in) :: command

--- a/src/execution/executor.f90
+++ b/src/execution/executor.f90
@@ -79,10 +79,22 @@ contains
     end do
   end subroutine
 
-  ! DEPRECATED: Legacy pipeline execution path, only used by FORTSH_USE_OLD_PARSER=1.
-  ! The AST executor (ast_executor.f90::execute_pipeline_node) is the primary pipeline
-  ! implementation with full feature parity. This subroutine will be removed when the
-  ! legacy parser path is retired.
+  ! Multi-stage pipe execution. LIVE, not deprecated: there is no
+  ! FORTSH_USE_OLD_PARSER toggle (grep src/ finds only this comment's former
+  ! wording). The real layering is AST-over-legacy delegation, not two
+  ! switchable engines:
+  !   ast_executor.f90 owns the AST / pipeline structure and delegates leaf
+  !   and simple-command execution to executor.f90::execute_pipeline
+  !   (ast_executor.f90:1067,1172). execute_pipeline (line 29) then dispatches
+  !   a genuine N-stage pipe to this routine (line 43), and also runs group,
+  !   subshell, alias, eval, and loop-body commands; command_builtin.f90 calls
+  !   it too.
+  ! Authoritative variable expansion is parser.f90::expand_variables (~32
+  ! sites); expansion.f90::enhanced_expand_variables (~3 sites) is niche. The
+  ! canonical tokenizer is parser.f90::tokenize_with_substitution;
+  ! syntax_highlight.f90::tokenize_v2 is highlighter-only. A fix to expansion
+  ! or tokenization must land in the authoritative copy, not silently in one
+  ! branch (cf. the QUAL-4 arithmetic-chain divergence).
   subroutine execute_pipe_chain(pipeline, start_idx, shell, original_input)
     type(pipeline_t), intent(inout) :: pipeline
     integer, intent(in) :: start_idx

--- a/src/io/readline.f90
+++ b/src/io/readline.f90
@@ -4,6 +4,7 @@
 ! ==============================================================================
 module readline
   use shell_types
+  use string_utils, only: to_lowercase => char_lower
   use system_interface
   use completion, only: get_completion_spec, generate_completions, completion_spec_t, MAX_COMPLETIONS
   use syntax_highlight, only: highlight_command_line, highlight_single_char, init_syntax_highlighting, MAX_HIGHLIGHT_LEN
@@ -9653,20 +9654,6 @@ contains
     end do
   end function
 
-  ! Helper: convert character to lowercase
-  function to_lowercase(c) result(lower)
-    character, intent(in) :: c
-    character :: lower
-    integer :: ascii_val
-
-    ascii_val = ichar(c)
-    if (ascii_val >= ichar('A') .and. ascii_val <= ichar('Z')) then
-      lower = char(ascii_val + 32)
-    else
-      lower = c
-    end if
-  end function
-
   ! Sort completions by fuzzy match score (bubble sort - good enough for small arrays)
   subroutine sort_completions_by_score(scored_completions, count)
     type(scored_completion_t), intent(inout) :: scored_completions(:)
@@ -9868,13 +9855,6 @@ contains
     ! Deallocate heap-allocated buffer
     if (allocated(highlighted)) deallocate(highlighted)
   end subroutine
-
-  ! Helper to convert integer to string
-  function int_to_str(n) result(str)
-    integer, intent(in) :: n
-    character(len=20) :: str
-    write(str, '(i15)') n
-  end function
 
   ! Advanced line editing functions for Phase 5
   subroutine handle_home(input_state)

--- a/src/io/suggestions.f90
+++ b/src/io/suggestions.f90
@@ -4,6 +4,7 @@
 ! Separated from readline for testability — no I/O, no terminal ops.
 ! ==============================================================================
 module suggestions
+  use string_utils, only: to_lower => char_lower
   implicit none
   private
 
@@ -113,19 +114,6 @@ contains
       end if
     end do
   end function compute_path_suggestion
-
-  ! ASCII lowercase of a single character (module is I/O-free by design).
-  pure function to_lower(c) result(lc)
-    character(len=1), intent(in) :: c
-    character(len=1) :: lc
-    integer :: code
-    code = iachar(c)
-    if (code >= iachar('A') .and. code <= iachar('Z')) then
-      lc = achar(code + 32)
-    else
-      lc = c
-    end if
-  end function to_lower
 
   ! --------------------------------------------------------------------------
   ! Compute a history-based suggestion.

--- a/src/parsing/parser.f90
+++ b/src/parsing/parser.f90
@@ -1362,8 +1362,11 @@ contains
     logical :: is_quoted, is_single_quoted
     logical :: escapes_already_processed  ! True if lexer already processed escapes
 
-    ! Initialize growing result buffer
-    result_cap = max(len(token) * 4, 16384)
+    ! Initialize growing result buffer. ensure_result_cap grows it on demand
+    ! (guarding every write, incl. the main loop's j+256 headroom), so this is
+    ! only an initial size — a small floor avoids a 16 KB allocation per token
+    ! while still covering typical short tokens without an early grow (QUAL-10).
+    result_cap = max(len(token) * 4, 512)
     allocate(character(len=result_cap) :: result)
 
     ! Check if token was originally quoted (from lexer metadata or token inspection)

--- a/src/scripting/expansion.f90
+++ b/src/scripting/expansion.f90
@@ -7,6 +7,7 @@ module expansion
   use variables  ! includes check_nounset
   use command_capture, only: execute_command_and_capture
   use glob, only: pattern_matches_no_dotfile_check
+  use string_utils, only: to_upper, to_lower
   use iso_fortran_env, only: output_unit, error_unit, int64
 #ifdef USE_C_STRINGS
   use iso_c_binding, only: c_char, c_int, c_null_char, c_ptr, c_f_pointer, c_size_t
@@ -1193,36 +1194,6 @@ contains
   ! ============================================================================
   ! Parameter Expansion Helper Functions
   ! ============================================================================
-
-  ! Convert string to uppercase
-  function to_upper(input) result(output)
-    character(len=*), intent(in) :: input
-    character(len=len(input)) :: output
-    integer :: i, char_code
-
-    output = input
-    do i = 1, len_trim(input)
-      char_code = ichar(input(i:i))
-      if (char_code >= ichar('a') .and. char_code <= ichar('z')) then
-        output(i:i) = char(char_code - 32)
-      end if
-    end do
-  end function
-
-  ! Convert string to lowercase
-  function to_lower(input) result(output)
-    character(len=*), intent(in) :: input
-    character(len=len(input)) :: output
-    integer :: i, char_code
-
-    output = input
-    do i = 1, len_trim(input)
-      char_code = ichar(input(i:i))
-      if (char_code >= ichar('A') .and. char_code <= ichar('Z')) then
-        output(i:i) = char(char_code + 32)
-      end if
-    end do
-  end function
 
   ! Quote value - wrap in single quotes and escape embedded single quotes
   ! Used for ${var@Q} transformation

--- a/src/scripting/printf_builtin.f90
+++ b/src/scripting/printf_builtin.f90
@@ -7,6 +7,7 @@ module printf_builtin
   use iso_fortran_env, only: output_unit, error_unit, int64
   use iso_c_binding, only: c_char, c_int, c_double, c_long_long, c_null_char
   use io_helpers, only: parse_int64
+  use string_utils, only: to_uppercase => to_upper, to_lowercase => to_lower
   implicit none
 
   ! Set when %b hits \c: all further printf output (including format
@@ -1166,31 +1167,5 @@ contains
       output_pos = output_pos + value_len
     end if
   end subroutine
-
-  function to_lowercase(str) result(lower_str)
-    character(len=*), intent(in) :: str
-    character(len=len(str)) :: lower_str
-    integer :: i
-
-    lower_str = str
-    do i = 1, len_trim(str)
-      if (str(i:i) >= 'A' .and. str(i:i) <= 'Z') then
-        lower_str(i:i) = char(ichar(str(i:i)) + 32)
-      end if
-    end do
-  end function
-
-  function to_uppercase(str) result(upper_str)
-    character(len=*), intent(in) :: str
-    character(len=len(str)) :: upper_str
-    integer :: i
-
-    upper_str = str
-    do i = 1, len_trim(str)
-      if (str(i:i) >= 'a' .and. str(i:i) <= 'z') then
-        upper_str(i:i) = char(ichar(str(i:i)) - 32)
-      end if
-    end do
-  end function
 
 end module printf_builtin

--- a/src/scripting/prompt_formatting.f90
+++ b/src/scripting/prompt_formatting.f90
@@ -9,6 +9,7 @@ module prompt_formatting
   use iso_fortran_env, only: output_unit
   use substitution, only: enhanced_command_substitution
   use variables, only: get_shell_variable
+  use string_utils, only: to_lower
   implicit none
 
   ! History counter for prompts
@@ -1015,21 +1016,6 @@ contains
     else
       write(ansi_code, '(a,i0,a)') char(27)//'[', 40 + base_code, 'm'
     end if
-  end function
-
-  ! Convert string to lowercase
-  function to_lower(str) result(lower)
-    character(len=*), intent(in) :: str
-    character(len=len(str)) :: lower
-    integer :: i, ic
-
-    lower = str
-    do i = 1, len_trim(str)
-      ic = iachar(str(i:i))
-      if (ic >= iachar('A') .and. ic <= iachar('Z')) then
-        lower(i:i) = achar(ic + 32)
-      end if
-    end do
   end function
 
   ! Expand zsh-style color escapes in a string

--- a/src/system/signals.f90
+++ b/src/system/signals.f90
@@ -6,6 +6,7 @@ module signal_handler
   use iso_c_binding
   use system_interface
   use shell_types
+  use string_utils, only: to_upper
   implicit none
 
   ! Additional signal constants not in system_interface
@@ -297,18 +298,5 @@ contains
     active_timeout%active = .false.
     active_timeout%target_pid = 0
   end subroutine
-
-  function to_upper(str) result(upper_str)
-    character(len=*), intent(in) :: str
-    character(len=len(str)) :: upper_str
-    integer :: i
-    
-    upper_str = str
-    do i = 1, len_trim(str)
-      if (str(i:i) >= 'a' .and. str(i:i) <= 'z') then
-        upper_str(i:i) = char(ichar(str(i:i)) - 32)
-      end if
-    end do
-  end function
 
 end module signal_handler


### PR DESCRIPTION
Wave 11 of the audit-remediation campaign: optional performance and maintainability cleanup, no correctness impact. All three findings addressed; the full suite stays green.

## QUAL-7 — dual engines and a phantom toggle comment
`executor.f90` carried a comment claiming `execute_pipeline` is "only used by `FORTSH_USE_OLD_PARSER=1`" — an env var that exists nowhere in the tree. Replaced it with an accurate description: `ast_executor` owns pipeline structure and delegates leaf/simple-command execution to `executor.f90::execute_pipeline`. This is AST-over-legacy layering, not two toggled engines. (`37d90d0`)

## QUAL-10 — arithmetic while-loop overhead
Baseline `i=0; while [ $i -lt 20000 ]; do i=$((i+1)); done`: fortsh ~2.00s vs bash ~0.027s.

- **Buffer floor** (`f666314`): `expand_variables` allocated a min-16KB result buffer per token. `ensure_result_cap` already grows on demand, so the floor only wasted allocation for short tokens. Dropped to 512B; long tokens still grow (verified).
- **Dispatch** (`dc53a4d`): `is_builtin` was a ~60-term `.or.` chain of `trim ==` comparisons (Fortran `.or.` is not guaranteed to short-circuit). Replaced with a first-character `select case` bucket so each dispatch compares only the few names sharing that initial letter; the test-command family (`[`, `[[`, `test`) stays as the fallback. ~8-10% faster on the loop (2.00s → ~1.79-1.84s); the dispatch set is unchanged, verified against every builtin plus near-miss rejection.
- **Arithmetic evaluator — deferred.** The finding's prescribed fix (avoid per-level `trim(adjustl)` copies) does not target the actual hot path: the delegate-down path passes the expression raw through ~14 levels, so those copies only occur at operator split points. The real cost is `find_operator` re-scanning the full string at each level, which needs an index-based rewrite of the correctness-critical recursive-descent evaluator — too much risk for an optional wave with only string-equality regression coverage. Left for a dedicated, well-tested refactor.

## QUAL-12 — duplicate case-conversion helpers
`to_upper`/`to_lower` were re-implemented (identical ASCII shifts) across six modules — expansion, signals, printf_builtin, prompt_formatting (string-level) and suggestions, readline (char-level). Added one leaf module `src/common/string_utils.f90` with string- and char-level helpers; consumers import it, renaming on import where their call sites used other names. Also deleted the dead `int_to_string`/`int_to_str` twins in coprocess and readline (defined, never called). Net -115 lines. (`c7e2e6c`)

## Verification
- Builtin suite: 1,151 passing.
- POSIX: 3,776 passing across 25 suites (clean sequential run).
- Interactive PTY: 1,079 YAML spec cases passing + 4 ci-marked pyte tests.
- Every case-conversion path smoke-checked (`${x^^}`/`${x,,}`, printf `%X`/`%x`, lowercase signal-name normalization).

## Note
A pre-existing crash unrelated to this wave was found while benchmarking and logged locally as DISC-7: `for i in $(seq 1 3000); do :; done` segfaults because `split_words` is sized `MAX_TOKENS=2000` while `split_on_ifs` returns an un-clamped field count; below the threshold it silently drops fields. Out of scope here; surfaced separately.
