### PR TITLE
v1.9.0: fix release-blocking prompt duplication regression gap, bump version

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = fortsh
 	pkgdesc = Fortran Shell - A modern shell implementation with AST-based parsing
-	pkgver = 1.8.0
+	pkgver = 1.9.0
 	pkgrel = 1
 	url = https://github.com/FortranGoingOnForty/fortsh
 	arch = x86_64
@@ -9,7 +9,7 @@ pkgbase = fortsh
 	makedepends = gcc-fortran
 	makedepends = make
 	depends = glibc
-	source = git+https://github.com/FortranGoingOnForty/fortsh.git#tag=v1.8.0
+	source = git+https://github.com/FortranGoingOnForty/fortsh.git#tag=v1.9.0
 	sha256sums = SKIP
 
 pkgname = fortsh

--- a/Makefile
+++ b/Makefile
@@ -688,8 +688,8 @@ $(BUILDDIR)/test_expansion_simple: tests/test_expansion_simple.f90 $(BUILDDIR)/c
 $(BUILDDIR)/test_variables_simple: tests/test_variables_simple.f90 $(BUILDDIR)/common/string_pool.o $(BUILDDIR)/common/memory_dashboard.o $(BUILDDIR)/common/types.o | $(BUILDDIR)
 	$(FC) $(FCFLAGS) -J$(BUILDDIR) $< $(BUILDDIR)/common/string_pool.o $(BUILDDIR)/common/memory_dashboard.o $(BUILDDIR)/common/types.o -o $@
 
-$(BUILDDIR)/test_suggestions: tests/test_suggestions.f90 $(BUILDDIR)/io/suggestions.o | $(BUILDDIR)
-	$(FC) $(FCFLAGS) -J$(BUILDDIR) $< $(BUILDDIR)/io/suggestions.o -o $@
+$(BUILDDIR)/test_suggestions: tests/test_suggestions.f90 $(BUILDDIR)/io/suggestions.o $(BUILDDIR)/common/string_utils.o | $(BUILDDIR)
+	$(FC) $(FCFLAGS) -J$(BUILDDIR) $< $(BUILDDIR)/io/suggestions.o $(BUILDDIR)/common/string_utils.o -o $@
 
 $(BUILDDIR)/test_syntax_highlight: tests/test_syntax_highlight.f90 $(BUILDDIR)/io/syntax_highlight.o $(CORE_C_OBJS) | $(BUILDDIR)
 	$(FC) $(FCFLAGS) -J$(BUILDDIR) $< $(BUILDDIR)/io/syntax_highlight.o $(BUILDDIR)/system/interface.o $(BUILDDIR)/common/types.o $(BUILDDIR)/common/string_pool.o $(BUILDDIR)/common/memory_dashboard.o $(CORE_C_OBJS) -o $@

--- a/Makefile
+++ b/Makefile
@@ -552,7 +552,7 @@ help:
 
 # Package information
 PACKAGE = fortsh
-VERSION = 1.0.1
+VERSION = 1.9.0
 # Legacy version (pre-semver reset): 6.0.6
 
 # Distribution and packaging targets

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: mfw <espadonne@outlook.com>
 
 pkgname=fortsh
-pkgver=1.8.0
+pkgver=1.9.0
 pkgrel=1
 pkgdesc='Fortran Shell - A modern shell implementation with AST-based parsing'
 arch=('x86_64' 'aarch64')

--- a/fortsh.spec
+++ b/fortsh.spec
@@ -1,5 +1,5 @@
 Name:           fortsh
-Version:        1.8.0
+Version:        1.9.0
 Release:        1%{?dist}
 Summary:        Fortran Shell - A modern shell implementation in Fortran with advanced features
 
@@ -59,6 +59,18 @@ install -Dm644 README.md %{buildroot}%{_docdir}/%{name}/README.md
 %{_docdir}/%{name}/README.md
 
 %changelog
+* Fri Jul 24 2026 mfw <espadon@outlook.com> - 1.9.0-1
+- Fix prompt duplication when typing " ` or $( — the per-keystroke directory
+  scan no longer builds a /bin/sh command from the typed word (native readdir)
+- Multi-line paste and editing; submit starts output below the whole buffer
+- Right prompt reworked as a row-0 re-emit layer; survives resize and redraw
+- Fish-parity completion pager with option and git-subcommand descriptions
+- Undo/redo, richer vi mode (text objects, visual mode, dot-repeat), abbreviations
+- Wrapped-line redraw fixes: recall, Ctrl-U, exact-width wrap, resize staircase
+- Security: mkstemp for fzf temp files, ps via execvp argv instead of popen
+- Memory: string-pool use-after-free and ref-accounting fixes, 64-bit size math
+- readline split from one 13k-line module into nine focused modules
+
 * Sun Mar 09 2026 mfw <espadon@outlook.com> - 1.3.3-1
 - Redesign Ctrl-R reverse search with fish-style two-line rendering
 - Fix heap corruption (SIGABRT) when accepting search suggestions

--- a/src/common/version.f90
+++ b/src/common/version.f90
@@ -7,7 +7,7 @@ module version
   private
   public :: FORTSH_VERSION, print_version, print_help
 
-  character(len=*), parameter :: FORTSH_VERSION = "1.8.0"
+  character(len=*), parameter :: FORTSH_VERSION = "1.9.0"
 
 contains
 

--- a/tests/interactive/test_quote_prompt_dup.py
+++ b/tests/interactive/test_quote_prompt_dup.py
@@ -1,0 +1,116 @@
+"""Regression: typing shell metacharacters must not duplicate the prompt.
+
+Class of bug (previously hit by #51, fixed in 6d85f03): a per-keystroke code
+path built a /bin/sh command string by concatenating the *typed word* into a
+double-quoted argument, e.g.
+
+    ls_command = 'ls -1aF "' // trim(expanded_dir) // '/" 2>/dev/null | grep -i "^' &
+                 // trim(pattern) // '"'
+
+An unbalanced `"` (or a backtick, or `$(`) in the buffer therefore made the
+child shell fail to parse its own command line and print
+
+    sh: -c: line 1: unexpected EOF while looking for matching `"'
+
+straight to the tty. That stray line + newline scrolls the display out from
+under readline, whose redraw tracks the prompt origin by row count — so the
+next redraw repaints the whole prompt one row lower. Typing `"` repeatedly
+walked a fresh copy of the prompt down the screen.
+
+The fix was to stop shelling out for directory enumeration at all (native
+opendir/readdir). This test locks the *behaviour*, not the implementation:
+while a line is being edited, nothing but readline may write to the terminal,
+so the prompt must appear exactly once no matter what metacharacters are typed.
+"""
+import os
+import time
+
+import pexpect
+import pytest
+
+try:
+    import pyte
+except ImportError:  # pragma: no cover
+    pyte = None
+
+pytestmark = [
+    pytest.mark.ci,
+    pytest.mark.prompt,
+    pytest.mark.skipif(pyte is None, reason="pyte not installed"),
+]
+
+ROWS, COLS = 24, 80
+
+# Distinctive first prompt line so counting occurrences is unambiguous, plus a
+# second line ('> ') and an RPROMPT — the two-line + right-prompt layout the
+# duplication was reported against.
+PROMPT_MARK = "FORTSH-PROMPT-MARK"
+RC_TEXT = "PS1='" + PROMPT_MARK + " \\w\n> '\nRPROMPT='rp'\n"
+
+# Metacharacters that are inert inside single quotes but break out of a
+# double-quoted shell word — exactly the ones that exposed the old shell-out.
+# ("'" is included as the control: it never triggered the bug.)
+METACHARS = ['"', '`', '$(', "'"]
+
+
+def _spawn(fortsh_path, rc_path):
+    env = dict(os.environ)
+    env["TERM"] = "xterm-256color"
+    env["FORTSH_RC_FILE"] = str(rc_path)
+    env["HISTFILE"] = "/dev/null"
+    return pexpect.spawn(fortsh_path, [], env=env, encoding=None,
+                         timeout=8, dimensions=(ROWS, COLS))
+
+
+@pytest.mark.parametrize("meta", METACHARS)
+def test_metachar_typing_does_not_duplicate_prompt(fortsh_path, tmp_path, meta):
+    rc = tmp_path / "quoterc"
+    rc.write_text(RC_TEXT)
+
+    child = _spawn(fortsh_path, rc)
+    screen = pyte.Screen(COLS, ROWS)
+    stream = pyte.ByteStream(screen)
+
+    def drain(secs=0.3):
+        chunk = bytearray()
+        end = time.time() + secs
+        while time.time() < end:
+            try:
+                data = child.read_nonblocking(65536, timeout=0.1)
+                chunk.extend(data)
+                stream.feed(data)
+            except pexpect.TIMEOUT:
+                pass
+            except pexpect.EOF:
+                break
+        return bytes(chunk)
+
+    try:
+        time.sleep(1.0)
+        drain(0.8)
+        child.send(b"\x0c")  # Ctrl-L: start from a clean screen
+        drain(0.5)
+
+        assert sum(1 for line in screen.display if PROMPT_MARK in line) == 1, (
+            "prompt did not render exactly once before typing"
+        )
+
+        emitted = bytearray()
+        for _ in range(6):
+            child.send(meta.encode())
+            emitted.extend(drain(0.3))
+
+        text = emitted.decode("utf-8", "replace")
+        # Nothing but readline may write while a line is being edited.
+        assert "sh:" not in text and "unexpected EOF" not in text, (
+            "a subprocess wrote to the tty while editing: " + repr(text[:400])
+        )
+
+        copies = sum(1 for line in screen.display if PROMPT_MARK in line)
+        assert copies == 1, (
+            "prompt duplicated %d times after typing %r:\n%s"
+            % (copies, meta,
+               "\n".join(l.rstrip() for l in screen.display if l.strip()))
+        )
+    finally:
+        child.terminate(force=True)

--- a/tests/interactive/test_quote_prompt_dup.py
+++ b/tests/interactive/test_quote_prompt_dup.py
@@ -43,9 +43,10 @@ ROWS, COLS = 24, 80
 
 # Distinctive first prompt line so counting occurrences is unambiguous, plus a
 # second line ('> ') and an RPROMPT — the two-line + right-prompt layout the
-# duplication was reported against.
+# duplication was reported against. No \w: the prompt must render identically
+# whatever directory the suite runs from.
 PROMPT_MARK = "FORTSH-PROMPT-MARK"
-RC_TEXT = "PS1='" + PROMPT_MARK + " \\w\n> '\nRPROMPT='rp'\n"
+RC_TEXT = "PS1='" + PROMPT_MARK + "\n> '\nRPROMPT='rp'\n"
 
 # Metacharacters that are inert inside single quotes but break out of a
 # double-quoted shell word — exactly the ones that exposed the old shell-out.
@@ -53,10 +54,17 @@ RC_TEXT = "PS1='" + PROMPT_MARK + " \\w\n> '\nRPROMPT='rp'\n"
 METACHARS = ['"', '`', '$(', "'"]
 
 
-def _spawn(fortsh_path, rc_path):
+def _spawn(fortsh_path, home):
     env = dict(os.environ)
     env["TERM"] = "xterm-256color"
-    env["FORTSH_RC_FILE"] = str(rc_path)
+    # Own HOME, holding the rc: without a ~/.fortshrc (or ~/.fortsh_profile)
+    # fortsh treats the session as a first run and blocks on
+    # "Create default configs? [Y/n]:", so the prompt never renders. A CI
+    # runner has no config; a developer's machine does. Pinning HOME makes the
+    # test behave the same on both. FORTSH_TEST_MODE would also skip that
+    # prompt, but it disables the redraw this test exists to exercise.
+    env["HOME"] = str(home)
+    env["FORTSH_RC_FILE"] = str(home / ".fortshrc")
     env["HISTFILE"] = "/dev/null"
     return pexpect.spawn(fortsh_path, [], env=env, encoding=None,
                          timeout=8, dimensions=(ROWS, COLS))
@@ -64,10 +72,9 @@ def _spawn(fortsh_path, rc_path):
 
 @pytest.mark.parametrize("meta", METACHARS)
 def test_metachar_typing_does_not_duplicate_prompt(fortsh_path, tmp_path, meta):
-    rc = tmp_path / "quoterc"
-    rc.write_text(RC_TEXT)
+    (tmp_path / ".fortshrc").write_text(RC_TEXT)
 
-    child = _spawn(fortsh_path, rc)
+    child = _spawn(fortsh_path, tmp_path)
     screen = pyte.Screen(COLS, ROWS)
     stream = pyte.ByteStream(screen)
 


### PR DESCRIPTION
## Why

The released **v1.8.0** duplicates the prompt when you type `"`. Its per-keystroke
directory scan built a `/bin/sh` command by concatenating the typed word into a
double-quoted argument:

```fortran
ls_command = 'ls -1aF "' // trim(expanded_dir) // '/" 2>/dev/null | grep -i "^' // &
  trim(pattern) // '"'
```

An unbalanced `"` therefore made the child shell fail to parse its own command line
and print `sh: -c: line 1: unexpected EOF while looking for matching \`"'` to the tty.
That stray line scrolls the screen out from under readline, whose redraw navigates by
counting rows back to the prompt origin — so the next repaint draws a fresh prompt one
row lower.

The defect itself was fixed by 6d85f03 (native `opendir`/`readdir`), which landed one
day *after* the v1.8.0 tag — so every packaged build still has it. What was missing was
a test and a release.

## What's here

- **`tests/interactive/test_quote_prompt_dup.py`** — pyte regression, `ci`-marked.
  Types `"`, `` ` ``, `$(` and `'` under a two-line PS1 + RPROMPT and asserts the prompt
  renders exactly once and that nothing but readline wrote to the tty. It pins the
  *behaviour*, so it also catches any future shell-out that leaks to the terminal.
  Verified: passes on trunk, fails on the v1.8.0 binary for all three metacharacters
  (`'` passes as the control).
- **`build:`** — `test_suggestions` never got `string_utils.o` added to its link line when
  QUAL-12 (c7e2e6c) moved `char_lower` there, so `make test` died at an undefined
  reference. Pre-existing on trunk.
- **`release:`** — 1.9.0 across `version.f90`, `PKGBUILD`, `fortsh.spec` and the Makefile
  `dist` VERSION (stale at 1.0.1), plus a spec changelog entry.

## Verification

- `make release` clean, `fortsh --version` → 1.9.0
- `make test` — all suites pass (204/204 stress, was failing to link before)
- `pytest -m ci` — 8 passed